### PR TITLE
Use product slug for details URL and add variant selection

### DIFF
--- a/components/ProductCollection.tsx
+++ b/components/ProductCollection.tsx
@@ -26,10 +26,18 @@ function Products() {
           {latestProducts?.length > 0 &&
             latestProducts.map(
               ({
-                node: { id, name, thumbnail, category, variants = [], pricing },
+                node: {
+                  id,
+                  slug,
+                  name,
+                  thumbnail,
+                  category,
+                  variants = [],
+                  pricing,
+                },
               }) => (
                 <li key={id} className="relative bg-white border">
-                  <Link href={`/products/${id}`}>
+                  <Link href={`/products/${slug}`}>
                     <a>
                       <div className="aspect-h-1 aspect-w-1">
                         <img

--- a/components/config.tsx
+++ b/components/config.tsx
@@ -15,6 +15,7 @@ export const ProductPaths = gql`
         cursor
         node {
           id
+          slug
         }
       }
     }
@@ -34,6 +35,7 @@ export const Products = gql`
         cursor
         node {
           id
+          slug
           name
           thumbnail {
             url
@@ -115,9 +117,9 @@ export const FilterProducts = gql`
   }
 `;
 
-export const ProductByID = gql`
-  query ProductByID($id: ID!) {
-    product(id: $id, channel: "default-channel") {
+export const ProductBySlug = gql`
+  query ProductBySlug($slug: String!) {
+    product(slug: $slug, channel: "default-channel") {
       id
       name
       description

--- a/pages/products/[slug].tsx
+++ b/pages/products/[slug].tsx
@@ -1,4 +1,4 @@
-import { GetStaticProps } from "next";
+import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
 import { ApolloQueryResult } from "@apollo/client";
 import Blocks from "editorjs-blocks-react-renderer";
@@ -6,99 +6,124 @@ import Blocks from "editorjs-blocks-react-renderer";
 import { Navbar } from "../../components/Navbar";
 import {
   useAddProductToCheckoutMutation,
-  useProductByIdQuery,
   Product,
   ProductPathsQuery,
+  useProductBySlugQuery,
 } from "../../saleor/api";
 import { ProductPaths } from "../../components/config";
 import apolloClient from "../../lib/graphql";
 import { formatAsMoney } from "../../lib/utils";
+import Link from "next/link";
+
+export const getStaticProps = async (context: GetStaticPropsContext) => {
+  return {
+    props: {
+      productSlug: context.params?.slug?.toString(),
+      token: "",
+    },
+  };
+};
 
 export default function ProductPage({
-  product,
+  productSlug,
   token,
-}: {
-  product: Product;
-  token: string;
-}) {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const router = useRouter();
 
-  const { loading, error, data } = useProductByIdQuery({ variables: product });
+  const { loading, error, data } = useProductBySlugQuery({
+    variables: { slug: productSlug || "" },
+  });
   const [addProductToCheckout] = useAddProductToCheckoutMutation();
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;
+  if (!data) {
+    return null;
+  }
 
-  if (data) {
-    const { product } = data;
-    const price = product?.pricing?.priceRange?.start?.gross.amount || 0;
-    const variantId = product?.variants![0]!.id!;
+  const { product } = data;
+  const price = product?.pricing?.priceRange?.start?.gross.amount || 0;
 
-    return (
-      <div className="min-h-screen bg-gray-100">
-        <Navbar />
+  const selectedVariantId =
+    router.query.variant?.toString() || product?.variants![0]!.id!;
 
-        <main className="max-w-7xl mx-auto pt-8 px-8">
-          <div className="grid grid-cols-2 gap-x-10 items-start">
-            <div className="w-full aspect-w-1 aspect-h-1 bg-white rounded">
-              <img
-                src={product?.media![0]?.url}
-                className="w-full h-full object-center object-cover"
-              />
+  const onAddToCart = async () => {
+    await addProductToCheckout({
+      variables: { checkoutId: token, variantId: selectedVariantId },
+    });
+    router.push("/cart");
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <Navbar />
+
+      <main className="max-w-7xl mx-auto pt-8 px-8">
+        <div className="grid grid-cols-2 gap-x-10 items-start">
+          <div className="w-full aspect-w-1 aspect-h-1 bg-white rounded">
+            <img
+              src={product?.media![0]?.url}
+              className="w-full h-full object-center object-cover"
+            />
+          </div>
+
+          <div className="space-y-8">
+            <div>
+              <h1 className="text-4xl font-bold tracking-tight text-gray-800">
+                {product?.name}
+              </h1>
+              <p className="text-lg mt-2 font-medium text-gray-500">
+                {product?.category?.name}
+              </p>
             </div>
 
-            <div className="space-y-8">
-              <div>
-                <h1 className="text-4xl font-bold tracking-tight text-gray-800">
-                  {product?.name}
-                </h1>
-                <p className="text-lg mt-2 font-medium text-gray-500">
-                  {product?.category?.name}
-                </p>
+            <p className="text-2xl text-gray-900">{formatAsMoney(price)}</p>
+
+            {!!product?.description && (
+              <div className="text-base text-gray-700 space-y-6">
+                <article className="prose lg:prose-s">
+                  <Blocks data={JSON.parse(product?.description)} />
+                </article>
               </div>
-
-              <p className="text-2xl text-gray-900">{formatAsMoney(price)}</p>
-
-              {!!product?.description && (
-                <div className="text-base text-gray-700 space-y-6">
-                  <article className="prose lg:prose-s">
-                    <Blocks data={JSON.parse(product?.description)} />
-                  </article>
-                </div>
-              )}
-              <div className="grid grid-cols-8 gap-2">
-                {product?.variants?.map((variant) => {
-                  return (
+            )}
+            <div className="grid grid-cols-8 gap-2">
+              {product?.variants?.map((variant) => {
+                return (
+                  <Link
+                    key={variant?.name}
+                    href={{
+                      pathname: "/products/[slug]",
+                      query: { variant: variant?.id, slug: productSlug },
+                    }}
+                    replace
+                    shallow
+                  >
                     <a
-                      key={variant?.name}
-                      className="flex justify-center border border-gray-300 rounded-md p-3 font-semibold hover:border-blue-300"
+                      className={`flex justify-center border rounded-md p-3 font-semibold hover:border-blue-400 ${
+                        variant?.id === selectedVariantId
+                          ? "border-blue-300"
+                          : "border-gray-300"
+                      }`}
                     >
                       {variant?.name}
                     </a>
-                  );
-                })}
-              </div>
-
-              <button
-                onClick={async () => {
-                  await addProductToCheckout({
-                    variables: { checkoutId: token, variantId },
-                  });
-                  router.push("/cart");
-                }}
-                type="submit"
-                className="max-w-xs w-full bg-blue-500 border border-transparent rounded-md py-3 px-8 flex items-center justify-center text-white hover:bg-blue-600 focus:outline-none"
-              >
-                Add to cart
-              </button>
+                  </Link>
+                );
+              })}
             </div>
-          </div>
-        </main>
-      </div>
-    );
-  }
 
-  return null;
+            <button
+              onClick={onAddToCart}
+              type="submit"
+              className="max-w-xs w-full bg-blue-500 border border-transparent rounded-md py-3 px-8 flex items-center justify-center text-white hover:bg-blue-600 focus:outline-none"
+            >
+              Add to cart
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
 }
 
 export async function getStaticPaths() {
@@ -109,7 +134,7 @@ export async function getStaticPaths() {
     });
   const paths = !!result
     ? result.data?.products?.edges.map(({ node }) => ({
-        params: { slug: node.id },
+        params: { slug: node.slug },
       }))
     : [];
 
@@ -118,13 +143,3 @@ export async function getStaticPaths() {
     fallback: false,
   };
 }
-
-export const getStaticProps: GetStaticProps<any> = async ({ params }) => {
-  const product = { id: params?.slug };
-
-  return {
-    props: {
-      product,
-    },
-  };
-};

--- a/saleor/api.tsx
+++ b/saleor/api.tsx
@@ -12647,7 +12647,7 @@ export type ProductPathsQueryVariables = Exact<{
 }>;
 
 
-export type ProductPathsQuery = { __typename?: 'Query', products?: Maybe<{ __typename?: 'ProductCountableConnection', edges: Array<{ __typename?: 'ProductCountableEdge', cursor: string, node: { __typename?: 'Product', id: string } }> }> };
+export type ProductPathsQuery = { __typename?: 'Query', products?: Maybe<{ __typename?: 'ProductCountableConnection', edges: Array<{ __typename?: 'ProductCountableEdge', cursor: string, node: { __typename?: 'Product', id: string, slug: string } }> }> };
 
 export type ProductsQueryVariables = Exact<{
   before?: Maybe<Scalars['String']>;
@@ -12655,7 +12655,7 @@ export type ProductsQueryVariables = Exact<{
 }>;
 
 
-export type ProductsQuery = { __typename?: 'Query', products?: Maybe<{ __typename?: 'ProductCountableConnection', edges: Array<{ __typename?: 'ProductCountableEdge', cursor: string, node: { __typename?: 'Product', id: string, name: string, thumbnail?: Maybe<{ __typename?: 'Image', url: string }>, category?: Maybe<{ __typename?: 'Category', name: string }>, variants?: Maybe<Array<Maybe<{ __typename?: 'ProductVariant', id: string, name: string }>>>, pricing?: Maybe<{ __typename?: 'ProductPricingInfo', priceRange?: Maybe<{ __typename?: 'TaxedMoneyRange', start?: Maybe<{ __typename?: 'TaxedMoney', gross: { __typename?: 'Money', amount: number } }>, stop?: Maybe<{ __typename?: 'TaxedMoney', gross: { __typename?: 'Money', amount: number } }> }> }> } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, startCursor?: Maybe<string>, endCursor?: Maybe<string> } }> };
+export type ProductsQuery = { __typename?: 'Query', products?: Maybe<{ __typename?: 'ProductCountableConnection', edges: Array<{ __typename?: 'ProductCountableEdge', cursor: string, node: { __typename?: 'Product', id: string, slug: string, name: string, thumbnail?: Maybe<{ __typename?: 'Image', url: string }>, category?: Maybe<{ __typename?: 'Category', name: string }>, variants?: Maybe<Array<Maybe<{ __typename?: 'ProductVariant', id: string, name: string }>>>, pricing?: Maybe<{ __typename?: 'ProductPricingInfo', priceRange?: Maybe<{ __typename?: 'TaxedMoneyRange', start?: Maybe<{ __typename?: 'TaxedMoney', gross: { __typename?: 'Money', amount: number } }>, stop?: Maybe<{ __typename?: 'TaxedMoney', gross: { __typename?: 'Money', amount: number } }> }> }> } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, startCursor?: Maybe<string>, endCursor?: Maybe<string> } }> };
 
 export type TShirtProductsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -12670,12 +12670,12 @@ export type FilterProductsQueryVariables = Exact<{
 
 export type FilterProductsQuery = { __typename?: 'Query', products?: Maybe<{ __typename?: 'ProductCountableConnection', edges: Array<{ __typename?: 'ProductCountableEdge', node: { __typename?: 'Product', id: string, name: string, thumbnail?: Maybe<{ __typename?: 'Image', url: string }>, category?: Maybe<{ __typename?: 'Category', name: string }> } }> }> };
 
-export type ProductByIdQueryVariables = Exact<{
-  id: Scalars['ID'];
+export type ProductBySlugQueryVariables = Exact<{
+  slug: Scalars['String'];
 }>;
 
 
-export type ProductByIdQuery = { __typename?: 'Query', product?: Maybe<{ __typename?: 'Product', id: string, name: string, description?: Maybe<any>, category?: Maybe<{ __typename?: 'Category', name: string }>, variants?: Maybe<Array<Maybe<{ __typename?: 'ProductVariant', id: string, name: string }>>>, pricing?: Maybe<{ __typename?: 'ProductPricingInfo', priceRange?: Maybe<{ __typename?: 'TaxedMoneyRange', start?: Maybe<{ __typename?: 'TaxedMoney', gross: { __typename?: 'Money', amount: number } }> }> }>, media?: Maybe<Array<{ __typename?: 'ProductMedia', url: string }>>, thumbnail?: Maybe<{ __typename?: 'Image', url: string }> }> };
+export type ProductBySlugQuery = { __typename?: 'Query', product?: Maybe<{ __typename?: 'Product', id: string, name: string, description?: Maybe<any>, category?: Maybe<{ __typename?: 'Category', name: string }>, variants?: Maybe<Array<Maybe<{ __typename?: 'ProductVariant', id: string, name: string }>>>, pricing?: Maybe<{ __typename?: 'ProductPricingInfo', priceRange?: Maybe<{ __typename?: 'TaxedMoneyRange', start?: Maybe<{ __typename?: 'TaxedMoney', gross: { __typename?: 'Money', amount: number } }> }> }>, media?: Maybe<Array<{ __typename?: 'ProductMedia', url: string }>>, thumbnail?: Maybe<{ __typename?: 'Image', url: string }> }> };
 
 export type CreateCheckoutMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -12763,6 +12763,7 @@ export const ProductPathsDocument = gql`
       cursor
       node {
         id
+        slug
       }
     }
   }
@@ -12803,6 +12804,7 @@ export const ProductsDocument = gql`
       cursor
       node {
         id
+        slug
         name
         thumbnail {
           url
@@ -12962,9 +12964,9 @@ export function useFilterProductsLazyQuery(baseOptions?: Apollo.LazyQueryHookOpt
 export type FilterProductsQueryHookResult = ReturnType<typeof useFilterProductsQuery>;
 export type FilterProductsLazyQueryHookResult = ReturnType<typeof useFilterProductsLazyQuery>;
 export type FilterProductsQueryResult = Apollo.QueryResult<FilterProductsQuery, FilterProductsQueryVariables>;
-export const ProductByIdDocument = gql`
-    query ProductByID($id: ID!) {
-  product(id: $id, channel: "default-channel") {
+export const ProductBySlugDocument = gql`
+    query ProductBySlug($slug: String!) {
+  product(slug: $slug, channel: "default-channel") {
     id
     name
     description
@@ -12998,32 +13000,32 @@ export const ProductByIdDocument = gql`
     `;
 
 /**
- * __useProductByIdQuery__
+ * __useProductBySlugQuery__
  *
- * To run a query within a React component, call `useProductByIdQuery` and pass it any options that fit your needs.
- * When your component renders, `useProductByIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useProductBySlugQuery` and pass it any options that fit your needs.
+ * When your component renders, `useProductBySlugQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useProductByIdQuery({
+ * const { data, loading, error } = useProductBySlugQuery({
  *   variables: {
- *      id: // value for 'id'
+ *      slug: // value for 'slug'
  *   },
  * });
  */
-export function useProductByIdQuery(baseOptions: Apollo.QueryHookOptions<ProductByIdQuery, ProductByIdQueryVariables>) {
+export function useProductBySlugQuery(baseOptions: Apollo.QueryHookOptions<ProductBySlugQuery, ProductBySlugQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ProductByIdQuery, ProductByIdQueryVariables>(ProductByIdDocument, options);
+        return Apollo.useQuery<ProductBySlugQuery, ProductBySlugQueryVariables>(ProductBySlugDocument, options);
       }
-export function useProductByIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProductByIdQuery, ProductByIdQueryVariables>) {
+export function useProductBySlugLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProductBySlugQuery, ProductBySlugQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ProductByIdQuery, ProductByIdQueryVariables>(ProductByIdDocument, options);
+          return Apollo.useLazyQuery<ProductBySlugQuery, ProductBySlugQueryVariables>(ProductBySlugDocument, options);
         }
-export type ProductByIdQueryHookResult = ReturnType<typeof useProductByIdQuery>;
-export type ProductByIdLazyQueryHookResult = ReturnType<typeof useProductByIdLazyQuery>;
-export type ProductByIdQueryResult = Apollo.QueryResult<ProductByIdQuery, ProductByIdQueryVariables>;
+export type ProductBySlugQueryHookResult = ReturnType<typeof useProductBySlugQuery>;
+export type ProductBySlugLazyQueryHookResult = ReturnType<typeof useProductBySlugLazyQuery>;
+export type ProductBySlugQueryResult = Apollo.QueryResult<ProductBySlugQuery, ProductBySlugQueryVariables>;
 export const CreateCheckoutDocument = gql`
     mutation CreateCheckout {
   checkoutCreate(


### PR DESCRIPTION
Changes:
- IMO slugs are more human readible, so it seems to be better choice for URL
- variant selection works now and add chosen variant to the url. Not sure if implemented it "the beast way", let me know if you would like this to be done differently 