### PR TITLE
fix: scroll on body disable when burger menu is open

### DIFF
--- a/apps/storefront/components/Navbar/Navbar.tsx
+++ b/apps/storefront/components/Navbar/Navbar.tsx
@@ -30,6 +30,11 @@ export function Navbar() {
         setBurgerOpen(false);
       }
     });
+    if (isBurgerOpen) {
+      document.body.classList.add("overflow-hidden");
+    } else {
+      document.body.classList.remove("overflow-hidden");
+    }
   });
 
   const counter =


### PR DESCRIPTION
Fixed the scrolling of body content, when the burger menu was opened at mobile device.