### PR TITLE
allow to set ALLOWED_SALEOR_API_REGEX in docker build

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -20,6 +20,9 @@ RUN rm .env
 ARG SALEOR_API_URL
 ENV SALEOR_API_URL ${SALEOR_API_URL:-http://localhost:8000/graphql/}
 
+ARG ALLOWED_SALEOR_API_REGEX
+ENV ALLOWED_SALEOR_API_REGEX ${ALLOWED_SALEOR_API_REGEX:-'^https:\/\/[a-z0-9\-\.]+\.saleor\.cloud\/graphql\/\\$'}
+
 ARG STOREFRONT_URL
 ENV STOREFRONT_URL ${STOREFRONT_URL:-http://localhost:3000}
 


### PR DESCRIPTION
fix ALLOWED_SALEOR_API_REGEX is not set inside docker container