### PR TITLE
fix: fix tile size

### DIFF
--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -110,7 +110,17 @@ export default async function Page(props: { params: { slug: string }; searchPara
 	return (
 		<section className="mx-auto grid max-w-7xl p-8">
 			<form className="grid gap-2 sm:grid-cols-2" action={addItem}>
-				{firstImage && <Image alt={firstImage.alt ?? ""} width={1024} height={1024} src={firstImage.url} />}
+				{firstImage && (
+					<div className="">
+						<Image
+							alt={firstImage.alt ?? ""}
+							width={1024}
+							height={1024}
+							src={firstImage.url}
+							contain="object-contain"
+						/>
+					</div>
+				)}
 				<div className="flex flex-col justify-between pt-6 sm:px-6 sm:pt-0">
 					<div>
 						<h1 className="flex-auto text-3xl font-bold tracking-tight text-slate-900">{product?.name}</h1>

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -117,7 +117,7 @@ export default async function Page(props: { params: { slug: string }; searchPara
 							width={1024}
 							height={1024}
 							src={firstImage.url}
-							contain="object-contain"
+							fit="object-contain"
 						/>
 					</div>
 				)}

--- a/src/ui/atoms/Image.tsx
+++ b/src/ui/atoms/Image.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import NextImage from "next/image";
 
 type Props = {
@@ -5,9 +6,11 @@ type Props = {
 	alt: string;
 	width: number;
 	height: number;
+	square?: boolean;
+	contain?: "object-contain" | "object-cover";
 };
 
-export const Image = ({ src, alt, width, height }: Props) => {
+export const Image = ({ src, alt, width, height, square = true, contain = "object-cover" }: Props) => {
 	return (
 		<div className="overflow-hidden rounded-md border bg-slate-50 hover:border-slate-500">
 			<NextImage
@@ -15,7 +18,11 @@ export const Image = ({ src, alt, width, height }: Props) => {
 				height={height}
 				alt={alt}
 				src={src}
-				className="h-full w-full object-cover object-center p-4 transition-transform hover:scale-110"
+				className={clsx(
+					"h-full w-full object-center p-4 transition-transform hover:scale-110",
+					square && "aspect-square",
+					contain,
+				)}
 			/>
 		</div>
 	);

--- a/src/ui/atoms/Image.tsx
+++ b/src/ui/atoms/Image.tsx
@@ -7,10 +7,10 @@ type Props = {
 	width: number;
 	height: number;
 	square?: boolean;
-	contain?: "object-contain" | "object-cover";
+	fit?: "object-contain" | "object-cover";
 };
 
-export const Image = ({ src, alt, width, height, square = true, contain = "object-cover" }: Props) => {
+export const Image = ({ src, alt, width, height, square = true, fit = "object-cover" }: Props) => {
 	return (
 		<div className="overflow-hidden rounded-md border bg-slate-50 hover:border-slate-500">
 			<NextImage
@@ -21,7 +21,7 @@ export const Image = ({ src, alt, width, height, square = true, contain = "objec
 				className={clsx(
 					"h-full w-full object-center p-4 transition-transform hover:scale-110",
 					square && "aspect-square",
-					contain,
+					fit,
 				)}
 			/>
 		</div>

--- a/src/ui/components/ProductElement.tsx
+++ b/src/ui/components/ProductElement.tsx
@@ -16,7 +16,7 @@ export function ProductElement(props: { product: ProductFragment }) {
 						alt={product.thumbnail.alt ?? ""}
 						width={512}
 						height={512}
-						contain="object-contain"
+						fit="object-contain"
 					/>
 				)}
 				<div className="mt-2 flex justify-between">

--- a/src/ui/components/ProductElement.tsx
+++ b/src/ui/components/ProductElement.tsx
@@ -11,7 +11,13 @@ export function ProductElement(props: { product: ProductFragment }) {
 		<Link href={`/products/${product.slug}`} key={product.id}>
 			<div>
 				{product?.thumbnail?.url && (
-					<Image src={product.thumbnail.url} alt={product.thumbnail.alt ?? ""} width={512} height={512} />
+					<Image
+						src={product.thumbnail.url}
+						alt={product.thumbnail.alt ?? ""}
+						width={512}
+						height={512}
+						contain="object-contain"
+					/>
 				)}
 				<div className="mt-2 flex justify-between">
 					<div>


### PR DESCRIPTION
FIx #911 issue.

Added additional props to be set in the `/ui/atoms/Image` component:
- `fit` to determine how the image should be fitted inside the parent container,
- `square` to specify whether we want to display the image in a square aspect ratio.

Below are examples of how it looks in some configurations:
- on product list:
![object-fit-variants](https://github.com/saleor/storefront/assets/27455716/33c95a9f-b93f-46b6-badd-bda389797dbe)
- on product page:
![Zrzut ekranu 2023-10-09 190912](https://github.com/saleor/storefront/assets/27455716/c40f1772-2337-41fe-a886-77de88b47867)

