### PR TITLE
fix: disable scroll for the links in the variant selector

### DIFF
--- a/src/ui/components/VariantSelector.tsx
+++ b/src/ui/components/VariantSelector.tsx
@@ -28,6 +28,7 @@ export function VariantSelector({
 							<Link
 								key={variant.id}
 								prefetch={true}
+								scroll={false}
 								href={isDisabled ? "#" : getHrefForVariant(product, variant)}
 								className={clsx(
 									isCurrentVariant


### PR DESCRIPTION
I suggest disabling the `scroll` behavior for links in the variant selector. Why? Especially on mobile devices, it can be a bit annoying that the page scrolls to the top every time the user changes the product variant. In some cases, all variants are visible only after scrolling down the page, as we have product thumbnails at the top.