### PR TITLE
fix(checkout): remove divider in SignIn sections and add vertical padding on Sign In button

### DIFF
--- a/src/checkout/sections/CheckoutForm/CheckoutForm.tsx
+++ b/src/checkout/sections/CheckoutForm/CheckoutForm.tsx
@@ -31,8 +31,8 @@ export const CheckoutForm = () => {
 				<>
 					{checkout?.isShippingRequired && (
 						<Suspense fallback={<AddressSectionSkeleton />}>
-							<Divider />
 							<CollapseSection collapse={showOnlyContact}>
+								<Divider />
 								<div className="py-4" data-testid="shippingAddressSection">
 									{user ? <UserShippingAddressSection /> : <GuestShippingAddressSection />}
 								</div>

--- a/src/checkout/sections/SignIn/SignIn.tsx
+++ b/src/checkout/sections/SignIn/SignIn.tsx
@@ -78,7 +78,7 @@ export const SignIn: React.FC<SignInProps> = ({
 						onEmailChange(event.currentTarget.value);
 					}}
 				/>
-				<PasswordInput name="password" label={formatMessage(contactMessages.password)} />
+				<PasswordInput name="password" label="Password" />
 				<div className="flex w-full flex-row items-center justify-end py-4">
 					<Button
 						ariaDisabled={isSubmitting}

--- a/src/checkout/sections/SignIn/SignIn.tsx
+++ b/src/checkout/sections/SignIn/SignIn.tsx
@@ -78,8 +78,8 @@ export const SignIn: React.FC<SignInProps> = ({
 						onEmailChange(event.currentTarget.value);
 					}}
 				/>
-				<PasswordInput name="password" label="Password" />
-				<div className="flex w-full flex-row items-center justify-end">
+				<PasswordInput name="password" label={formatMessage(contactMessages.password)} />
+				<div className="flex w-full flex-row items-center justify-end py-4">
 					<Button
 						ariaDisabled={isSubmitting}
 						ariaLabel="send password reset link"


### PR DESCRIPTION
- Fix #976 issue by removing divider (horizontal line) and adding 1rem vertical padding on Sign In button

<img width="636" alt="Screen Shot 2023-10-21 at 1 46 41 AM" src="https://github.com/saleor/storefront/assets/91102425/676a0e25-b3cb-425e-a108-aeae55abb61d">
