### PR TITLE
fix: remove unnecessary currency symbol from checkout summary

### DIFF
--- a/src/checkout/sections/Summary/Summary.tsx
+++ b/src/checkout/sections/Summary/Summary.tsx
@@ -92,7 +92,7 @@ export const Summary: FC<SummaryProps> = ({
 					<div className="flex flex-row items-baseline">
 						<p className="font-bold">Total price</p>
 						<p color="secondary" className="ml-2">
-							includes ${getFormattedMoney(totalPrice?.tax)} tax
+							includes {getFormattedMoney(totalPrice?.tax)} tax
 						</p>
 					</div>
 					<Money ariaLabel="total price" money={totalPrice?.gross} data-testid="totalOrderPrice" />


### PR DESCRIPTION
![Zrzut ekranu 2023-10-26 012134](https://github.com/saleor/storefront/assets/27455716/e90ad7ba-de5e-4426-b497-5086d64e48bf)
