### PR TITLE
fix: fix reveal password button in password input field

### DIFF
--- a/src/checkout/components/AddressForm/AddressForm.tsx
+++ b/src/checkout/components/AddressForm/AddressForm.tsx
@@ -76,7 +76,7 @@ export const AddressForm: FC<PropsWithChildren<AddressFormProps>> = ({
 				<Title className="flex-1">{title}</Title>
 				<CountrySelect only={availableCountries} />
 			</div>
-			<div className="mt-2 grid grid-cols-1 gap-2">
+			<div className="mt-2 grid grid-cols-1 gap-3">
 				{orderedAddressFields.map((field) => {
 					const isRequired = isRequiredField(field);
 					const label = getFieldLabel(field);

--- a/src/checkout/components/IconButton.tsx
+++ b/src/checkout/components/IconButton.tsx
@@ -10,7 +10,7 @@ export const IconButton = ({ icon, ariaLabel, ...rest }: IconButtonProps) => {
 		<button
 			aria-label={ariaLabel}
 			type="button"
-			className="mt-1 block w-full appearance-none rounded-md transition-colors focus:outline-none focus:ring focus:ring-neutral-200 focus:ring-opacity-50 active:shadow-sm active:outline-none active:ring active:ring-neutral-200 active:ring-opacity-75"
+			className="block w-full appearance-none rounded-md transition-colors focus:outline-none focus:ring focus:ring-neutral-200 focus:ring-opacity-50 active:shadow-sm active:outline-none active:ring active:ring-neutral-200 active:ring-opacity-75"
 			{...rest}
 		>
 			{icon}

--- a/src/checkout/components/ManualSaveAddressForm/AddressFormActions.tsx
+++ b/src/checkout/components/ManualSaveAddressForm/AddressFormActions.tsx
@@ -17,7 +17,11 @@ export const AddressFormActions: React.FC<AddressFormActionsProps> = ({
 }) => {
 	return (
 		<div className="flex flex-row justify-end">
-			{onDelete && <IconButton ariaLabel="Delete address" onClick={onDelete} icon={<TrashIcon />} />}
+			{onDelete && (
+				<div className="mt-1">
+					<IconButton ariaLabel="Delete address" onClick={onDelete} icon={<TrashIcon />} />
+				</div>
+			)}
 
 			<Button
 				className="mr-2"

--- a/src/checkout/components/PasswordInput/PasswordInput.tsx
+++ b/src/checkout/components/PasswordInput/PasswordInput.tsx
@@ -27,7 +27,7 @@ export const PasswordInputComponent = <TName extends string>({
 	const inputId = useId();
 
 	return (
-		<div>
+		<div className="mt-1 space-y-0.5 first:mt-0">
 			<div className="flex flex-col">
 				<label className="text-xs text-neutral-700" htmlFor={inputId}>
 					{label}

--- a/src/checkout/components/PasswordInput/PasswordInput.tsx
+++ b/src/checkout/components/PasswordInput/PasswordInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type AllHTMLAttributes, useId } from "react";
+import { useState, type AllHTMLAttributes } from "react";
 import clsx from "clsx";
 import { Field, type FieldProps } from "formik";
 import { EyeHiddenIcon, EyeIcon } from "@/checkout/ui-kit/icons";
@@ -24,12 +24,11 @@ export const PasswordInputComponent = <TName extends string>({
 }: PasswordInputProps<TName> & FieldProps) => {
 	const error = touched[field.name] ? (errors[field.name] as string) : undefined;
 	const [passwordVisible, setPasswordVisible] = useState(false);
-	const inputId = useId();
 
 	return (
 		<div className="mt-1 space-y-0.5 first:mt-0">
 			<div className="flex flex-col">
-				<label className="text-xs text-neutral-700" htmlFor={inputId}>
+				<label className="text-xs text-neutral-700">
 					{label}
 					{required && "*"}
 				</label>
@@ -45,9 +44,6 @@ export const PasswordInputComponent = <TName extends string>({
 							{ "border-red-300": error },
 							props.className,
 						)}
-						id={inputId}
-						aria-invalid={Boolean(error)}
-						aria-errormessage={`${inputId}-erorr-message`}
 					/>
 					<div className="mt-0.5 flex items-center justify-center">
 						<IconButton
@@ -59,11 +55,7 @@ export const PasswordInputComponent = <TName extends string>({
 					</div>
 				</div>
 			</div>
-			{error && (
-				<p className="text-sm text-red-500" id={`${inputId}-erorr-message`}>
-					{error}
-				</p>
-			)}
+			{error && <p className="text-sm text-red-500">{error}</p>}
 		</div>
 	);
 };

--- a/src/checkout/components/PasswordInput/PasswordInput.tsx
+++ b/src/checkout/components/PasswordInput/PasswordInput.tsx
@@ -26,7 +26,7 @@ export const PasswordInputComponent = <TName extends string>({
 	const [passwordVisible, setPasswordVisible] = useState(false);
 
 	return (
-		<div className="mt-1 space-y-0.5 first:mt-0">
+		<div className="space-y-0.5">
 			<div className="flex flex-col">
 				<label className="text-xs text-neutral-700">
 					{label}

--- a/src/checkout/components/PasswordInput/PasswordInput.tsx
+++ b/src/checkout/components/PasswordInput/PasswordInput.tsx
@@ -1,21 +1,63 @@
-import { useState } from "react";
+"use client";
+
+import { useState, type AllHTMLAttributes, useId } from "react";
+import clsx from "clsx";
+import { Field, type FieldProps } from "formik";
 import { EyeHiddenIcon, EyeIcon } from "@/checkout/ui-kit/icons";
 import { IconButton } from "@/checkout/components/IconButton";
-import { TextInput, type TextInputProps } from "@/checkout/components/TextInput";
 
-export const PasswordInput = <TName extends string>(props: TextInputProps<TName>) => {
+export interface PasswordInputProps<TName extends string> extends AllHTMLAttributes<HTMLInputElement> {
+	name: TName;
+	label: string;
+}
+
+export const PasswordInput = <TName extends string>(props: PasswordInputProps<TName>) => (
+	<Field {...props} component={PasswordInputComponent} />
+);
+
+export const PasswordInputComponent = <TName extends string>({
+	field,
+	form: { touched, errors },
+	label,
+	required,
+	...props
+}: PasswordInputProps<TName> & FieldProps) => {
+	const error = touched[field.name] ? (errors[field.name] as string) : undefined;
 	const [passwordVisible, setPasswordVisible] = useState(false);
+	const inputId = useId();
 
 	return (
-		<div className="relative">
-			<TextInput required {...props} type={passwordVisible ? "text" : "password"} />
-			<div className="absolute right-7 top-6 flex h-10 items-center justify-center pr-4">
-				<IconButton
-					ariaLabel="change password visibility"
-					onClick={() => setPasswordVisible(!passwordVisible)}
-					icon={passwordVisible ? <EyeIcon /> : <EyeHiddenIcon />}
-				/>
+		<div>
+			<div className="flex flex-col">
+				<label className="text-xs text-neutral-700" htmlFor={inputId}>
+					{label}
+					{required && "*"}
+				</label>
+				<div className="mt-0.5 flex shadow-sm">
+					<input
+						required={required}
+						spellCheck={false}
+						type={passwordVisible ? "text" : "password"}
+						{...field}
+						{...props}
+						className={clsx(
+							"mt-0.5 block w-full appearance-none rounded-l-md border-neutral-300 transition-colors focus:border-neutral-300 focus:outline-none focus:ring focus:ring-neutral-200 focus:ring-opacity-50 active:border-neutral-200 active:outline-none",
+							{ "border-red-300": error },
+							props.className,
+						)}
+						id={inputId}
+					/>
+					<div className="mt-0.5 flex items-center justify-center">
+						<IconButton
+							ariaLabel="change password visibility"
+							onClick={() => setPasswordVisible(!passwordVisible)}
+							icon={passwordVisible ? <EyeIcon /> : <EyeHiddenIcon />}
+							className="h-full w-full rounded-r-md border border-l-0 border-neutral-300 bg-white px-3 focus:border-neutral-300 focus:outline-none focus:ring focus:ring-neutral-200 focus:ring-opacity-50 active:border-neutral-200 active:outline-none"
+						/>
+					</div>
+				</div>
 			</div>
+			{error && <p className="text-sm text-red-500">{error}</p>}
 		</div>
 	);
 };

--- a/src/checkout/components/PasswordInput/PasswordInput.tsx
+++ b/src/checkout/components/PasswordInput/PasswordInput.tsx
@@ -46,6 +46,8 @@ export const PasswordInputComponent = <TName extends string>({
 							props.className,
 						)}
 						id={inputId}
+						aria-invalid={Boolean(error)}
+						aria-errormessage={`${inputId}-erorr-message`}
 					/>
 					<div className="mt-0.5 flex items-center justify-center">
 						<IconButton
@@ -57,7 +59,11 @@ export const PasswordInputComponent = <TName extends string>({
 					</div>
 				</div>
 			</div>
-			{error && <p className="text-sm text-red-500">{error}</p>}
+			{error && (
+				<p className="text-sm text-red-500" id={`${inputId}-erorr-message`}>
+					{error}
+				</p>
+			)}
 		</div>
 	);
 };

--- a/src/checkout/components/Select.tsx
+++ b/src/checkout/components/Select.tsx
@@ -39,8 +39,6 @@ export const Select = <TName extends string, TData extends string>({
 		fieldProps.onChange(event);
 	};
 
-	const errorMessageID = `${name}-error-message`;
-
 	return (
 		<div className="mt-1 space-y-0.5 first:mt-0">
 			<label className="flex flex-col">
@@ -51,8 +49,6 @@ export const Select = <TName extends string, TData extends string>({
 					onBlur={handleBlur}
 					onChange={handleChange}
 					className="mt-1 block w-full rounded-md border-neutral-300 shadow-sm focus:border-neutral-300 focus:ring focus:ring-neutral-200 focus:ring-opacity-50"
-					aria-invalid={Boolean(error)}
-					aria-errormessage={errorMessageID}
 				>
 					{showPlaceholder && (
 						<option disabled value="">
@@ -66,11 +62,7 @@ export const Select = <TName extends string, TData extends string>({
 					))}
 				</select>
 			</label>
-			{error && (
-				<p className="text-sm text-red-500" id={errorMessageID}>
-					{error}
-				</p>
-			)}
+			{error && <p className="text-sm text-red-500">{error}</p>}
 		</div>
 	);
 };

--- a/src/checkout/components/Select.tsx
+++ b/src/checkout/components/Select.tsx
@@ -39,9 +39,11 @@ export const Select = <TName extends string, TData extends string>({
 		fieldProps.onChange(event);
 	};
 
+	const errorMessageID = `${name}-error-message`;
+
 	return (
-		<div>
-			<label className="block">
+		<div className="mt-1 space-y-0.5 first:mt-0">
+			<label className="flex flex-col">
 				<span className="text-xs text-neutral-700">{label}</span>
 				<select
 					{...fieldProps}
@@ -49,6 +51,8 @@ export const Select = <TName extends string, TData extends string>({
 					onBlur={handleBlur}
 					onChange={handleChange}
 					className="mt-1 block w-full rounded-md border-neutral-300 shadow-sm focus:border-neutral-300 focus:ring focus:ring-neutral-200 focus:ring-opacity-50"
+					aria-invalid={Boolean(error)}
+					aria-errormessage={errorMessageID}
 				>
 					{showPlaceholder && (
 						<option disabled value="">
@@ -62,7 +66,11 @@ export const Select = <TName extends string, TData extends string>({
 					))}
 				</select>
 			</label>
-			{error && <p className="text-sm text-red-500">{error}</p>}
+			{error && (
+				<p className="text-sm text-red-500" id={errorMessageID}>
+					{error}
+				</p>
+			)}
 		</div>
 	);
 };

--- a/src/checkout/components/Select.tsx
+++ b/src/checkout/components/Select.tsx
@@ -40,7 +40,7 @@ export const Select = <TName extends string, TData extends string>({
 	};
 
 	return (
-		<div className="mt-1 space-y-0.5 first:mt-0">
+		<div className="space-y-0.5">
 			<label className="flex flex-col">
 				<span className="text-xs text-neutral-700">{label}</span>
 				<select

--- a/src/checkout/components/TextInput.tsx
+++ b/src/checkout/components/TextInput.tsx
@@ -21,7 +21,7 @@ export const TextInputComponent = <TName extends string>({
 	const error = touched[field.name] ? (errors[field.name] as string) : undefined;
 
 	return (
-		<div className="mt-1 space-y-0.5 first:mt-0">
+		<div className="space-y-0.5">
 			<label className="flex flex-col">
 				<span className="text-xs text-neutral-700">
 					{label}

--- a/src/checkout/components/TextInput.tsx
+++ b/src/checkout/components/TextInput.tsx
@@ -21,8 +21,8 @@ export const TextInputComponent = <TName extends string>({
 	const error = touched[field.name] ? (errors[field.name] as string) : undefined;
 
 	return (
-		<div>
-			<label className="block">
+		<div className="mt-1 space-y-0.5 first:mt-0">
+			<label className="flex flex-col">
 				<span className="text-xs text-neutral-700">
 					{label}
 					{required && "*"}
@@ -33,7 +33,7 @@ export const TextInputComponent = <TName extends string>({
 					{...field}
 					{...props}
 					className={clsx(
-						"mt-0.5 block w-full appearance-none rounded-md border-neutral-300 shadow-sm transition-colors focus:border-neutral-300 focus:outline-none focus:ring focus:ring-neutral-200 focus:ring-opacity-50 active:border-neutral-200 active:outline-none",
+						"mt-0.5 w-full appearance-none rounded-md border-neutral-300 shadow-sm transition-colors focus:border-neutral-300 focus:outline-none focus:ring focus:ring-neutral-200 focus:ring-opacity-50 active:border-neutral-200 active:outline-none",
 						{ "border-red-300": error },
 						props.className,
 					)}

--- a/src/checkout/components/TextInput.tsx
+++ b/src/checkout/components/TextInput.tsx
@@ -19,7 +19,6 @@ export const TextInputComponent = <TName extends string>({
 	...props
 }: TextInputProps<TName> & FieldProps) => {
 	const error = touched[field.name] ? (errors[field.name] as string) : undefined;
-	const errorMessageID = `${field.name}-error-message`;
 
 	return (
 		<div className="mt-1 space-y-0.5 first:mt-0">
@@ -38,15 +37,9 @@ export const TextInputComponent = <TName extends string>({
 						{ "border-red-300": error },
 						props.className,
 					)}
-					aria-invalid={Boolean(error)}
-					aria-errormessage={errorMessageID}
 				/>
 			</label>
-			{error && (
-				<p className="text-sm text-red-500" id={errorMessageID}>
-					{error}
-				</p>
-			)}
+			{error && <p className="text-sm text-red-500">{error}</p>}
 		</div>
 	);
 };

--- a/src/checkout/components/TextInput.tsx
+++ b/src/checkout/components/TextInput.tsx
@@ -19,6 +19,7 @@ export const TextInputComponent = <TName extends string>({
 	...props
 }: TextInputProps<TName> & FieldProps) => {
 	const error = touched[field.name] ? (errors[field.name] as string) : undefined;
+	const errorMessageID = `${field.name}-error-message`;
 
 	return (
 		<div className="mt-1 space-y-0.5 first:mt-0">
@@ -37,9 +38,15 @@ export const TextInputComponent = <TName extends string>({
 						{ "border-red-300": error },
 						props.className,
 					)}
+					aria-invalid={Boolean(error)}
+					aria-errormessage={errorMessageID}
 				/>
 			</label>
-			{error && <p className="text-sm text-red-500">{error}</p>}
+			{error && (
+				<p className="text-sm text-red-500" id={errorMessageID}>
+					{error}
+				</p>
+			)}
 		</div>
 	);
 };

--- a/src/checkout/sections/Contact/SignInFormContainer.tsx
+++ b/src/checkout/sections/Contact/SignInFormContainer.tsx
@@ -31,7 +31,7 @@ export const SignInFormContainer: React.FC<PropsWithChildren<SignInFormContainer
 						)}
 						{redirectButtonLabel && (
 							<Button
-								ariaLabel="change section"
+								ariaLabel={redirectButtonLabel}
 								onClick={onSectionChange}
 								variant="tertiary"
 								label={redirectButtonLabel}

--- a/src/checkout/sections/GuestUser/GuestUser.tsx
+++ b/src/checkout/sections/GuestUser/GuestUser.tsx
@@ -27,7 +27,7 @@ export const GuestUser: React.FC<GuestUserProps> = ({
 			onSectionChange={onSectionChange}
 		>
 			<FormProvider form={form}>
-				<div className="grid grid-cols-1 gap-2">
+				<div className="grid grid-cols-1 gap-3">
 					<TextInput
 						required
 						name="email"

--- a/src/checkout/sections/GuestUser/GuestUser.tsx
+++ b/src/checkout/sections/GuestUser/GuestUser.tsx
@@ -44,7 +44,7 @@ export const GuestUser: React.FC<GuestUserProps> = ({
 					/>
 					{createAccount && (
 						<div className="mt-2">
-							<PasswordInput name="password" label="Password (minimum 8 characters)" />
+							<PasswordInput name="password" label="Password (minimum 8 characters)" required />
 						</div>
 					)}
 				</div>

--- a/src/checkout/sections/ResetPassword/ResetPassword.tsx
+++ b/src/checkout/sections/ResetPassword/ResetPassword.tsx
@@ -21,7 +21,7 @@ export const ResetPassword: React.FC<ResetPasswordProps> = ({ onSectionChange, o
 			subtitle="Provide a new password for your account"
 		>
 			<FormProvider form={form}>
-				<PasswordInput name="password" label="Password" />
+				<PasswordInput name="password" label="Password" required />
 				<div className="mt-4 flex w-full flex-row items-center justify-end">
 					<Button ariaLabel="Reset password" label="Reset password" type="submit" />
 				</div>

--- a/src/checkout/sections/SignIn/SignIn.tsx
+++ b/src/checkout/sections/SignIn/SignIn.tsx
@@ -78,7 +78,7 @@ export const SignIn: React.FC<SignInProps> = ({
 						onEmailChange(event.currentTarget.value);
 					}}
 				/>
-				<PasswordInput name="password" label="Password" />
+				<PasswordInput name="password" label="Password" required />
 				<div className="flex w-full flex-row items-center justify-end py-4">
 					<Button
 						ariaDisabled={isSubmitting}

--- a/src/checkout/sections/SignIn/SignIn.tsx
+++ b/src/checkout/sections/SignIn/SignIn.tsx
@@ -69,31 +69,33 @@ export const SignIn: React.FC<SignInProps> = ({
 			onSectionChange={onSectionChange}
 		>
 			<FormProvider form={form}>
-				<TextInput
-					required
-					name="email"
-					label="Email"
-					onChange={(event) => {
-						handleChange(event);
-						onEmailChange(event.currentTarget.value);
-					}}
-				/>
-				<PasswordInput name="password" label="Password" required />
-				<div className="flex w-full flex-row items-center justify-end py-4">
-					<Button
-						ariaDisabled={isSubmitting}
-						ariaLabel="send password reset link"
-						variant="tertiary"
-						label={passwordResetSent ? "Resend?" : "Forgot password?"}
-						className="ml-1 mr-4"
-						onClick={(e) => (isSubmitting ? e.preventDefault() : onPasswordResetRequest)}
+				<div className="grid grid-cols-1 gap-3">
+					<TextInput
+						required
+						name="email"
+						label="Email"
+						onChange={(event) => {
+							handleChange(event);
+							onEmailChange(event.currentTarget.value);
+						}}
 					/>
-					<Button
-						type="submit"
-						disabled={isSubmitting}
-						ariaLabel={"Sign in"}
-						label={isSubmitting ? "Processing…" : "Sign in"}
-					/>
+					<PasswordInput name="password" label="Password" required />
+					<div className="flex w-full flex-row items-center justify-end">
+						<Button
+							ariaDisabled={isSubmitting}
+							ariaLabel="send password reset link"
+							variant="tertiary"
+							label={passwordResetSent ? "Resend?" : "Forgot password?"}
+							className="ml-1 mr-4"
+							onClick={(e) => (isSubmitting ? e.preventDefault() : onPasswordResetRequest)}
+						/>
+						<Button
+							type="submit"
+							disabled={isSubmitting}
+							ariaLabel={"Sign in"}
+							label={isSubmitting ? "Processing…" : "Sign in"}
+						/>
+					</div>
 				</div>
 			</FormProvider>
 		</SignInFormContainer>

--- a/src/checkout/sections/Summary/SummaryItem.tsx
+++ b/src/checkout/sections/Summary/SummaryItem.tsx
@@ -16,7 +16,7 @@ export const SummaryItem = ({ line, children }: SummaryItemProps) => {
 	const attributesText = useSummaryLineLineAttributesText(line);
 
 	return (
-		<li className="relative mb-6 flex flex-row items-start justify-between last-of-type:mb-0">
+		<li className="relative mb-6 flex flex-row items-start last-of-type:mb-0">
 			<div className="relative flex flex-row">
 				<div className="z-1 mr-4 flex h-24 w-20 items-center justify-start">
 					{productImage ? (
@@ -26,7 +26,7 @@ export const SummaryItem = ({ line, children }: SummaryItemProps) => {
 					)}
 				</div>
 			</div>
-			<div className="flex w-full items-center justify-between gap-2 md:flex-row">
+			<div className="flex w-full items-center justify-between gap-2">
 				<div className="flex w-full grow flex-col">
 					<p aria-label="summary item name" className="mb-3 font-bold">
 						{productName}

--- a/src/checkout/sections/Summary/SummaryItem.tsx
+++ b/src/checkout/sections/Summary/SummaryItem.tsx
@@ -16,7 +16,7 @@ export const SummaryItem = ({ line, children }: SummaryItemProps) => {
 	const attributesText = useSummaryLineLineAttributesText(line);
 
 	return (
-		<li className="relative mb-6 flex flex-row items-start last-of-type:mb-0">
+		<li className="relative mb-6 flex flex-row items-start justify-between last-of-type:mb-0">
 			<div className="relative flex flex-row">
 				<div className="z-1 mr-4 flex h-24 w-20 items-center justify-start">
 					{productImage ? (
@@ -26,8 +26,8 @@ export const SummaryItem = ({ line, children }: SummaryItemProps) => {
 					)}
 				</div>
 			</div>
-			<div className="flex w-full flex-row items-center justify-between">
-				<div className="flex flex-col">
+			<div className="flex w-full items-center justify-between gap-2 md:flex-row">
+				<div className="flex w-full grow flex-col">
 					<p aria-label="summary item name" className="mb-3 font-bold">
 						{productName}
 					</p>

--- a/src/checkout/sections/Summary/SummaryItemMoneyInfo.tsx
+++ b/src/checkout/sections/Summary/SummaryItemMoneyInfo.tsx
@@ -22,7 +22,7 @@ export const SummaryItemMoneyInfo: React.FC<SummaryItemMoneyInfoProps> = ({
 
 	return (
 		<>
-			<div className="flex flex-row">
+			<div className="mt-1 flex flex-row">
 				{onSale && (
 					<Money
 						ariaLabel="undiscounted price"

--- a/src/checkout/sections/Summary/SummaryPromoCodeRow.tsx
+++ b/src/checkout/sections/Summary/SummaryPromoCodeRow.tsx
@@ -33,7 +33,11 @@ export const SummaryPromoCodeRow: React.FC<SummaryPromoCodeRowProps> = ({
 
 	return (
 		<SummaryMoneyRow {...rest}>
-			{editable && <IconButton onClick={onDelete} ariaLabel="remove promo code" icon={<RemoveIcon />} />}
+			{editable && (
+				<div className="mt-1">
+					<IconButton onClick={onDelete} ariaLabel="remove promo code" icon={<RemoveIcon />} />
+				</div>
+			)}
 		</SummaryMoneyRow>
 	);
 };


### PR DESCRIPTION
Proposal for solving #992 issue.

I have rewritten the `PasswordInput` component. Most of its code comes from the `TextInput` component because I couldn't found any good way to change styles, except by inserting the `IconButton` into old `PasswordInput` component structure including its functionality to change input field type.

![after](https://github.com/saleor/storefront/assets/27455716/d40a1b78-10b9-4697-8398-acc76b32447e)
![long password](https://github.com/saleor/storefront/assets/27455716/5ad94a35-2063-4ce1-b59e-c153cb726b01)

Also introduced some style adjustments.
![ff](https://github.com/saleor/storefront/assets/27455716/83d9d20b-08e5-4b62-a49d-8c0be50d7d62)

