### PR TITLE
Auto-captialize postal code #1024

### DIFF
--- a/src/checkout/components/AddressForm/utils.ts
+++ b/src/checkout/components/AddressForm/utils.ts
@@ -47,16 +47,21 @@ export const getAllAddressFieldKeys = () => Object.keys(getEmptyAddressFormData(
 export const getAddressInputData = ({
 	countryCode,
 	country,
+	postalCode,
 	...rest
 }: Partial<
 	AddressFormData & {
 		countryCode?: CountryCode;
 		country: CountryDisplay;
 	}
->): AddressInput => ({
-	...pick(rest, getAllAddressFieldKeys()),
-	country: countryCode || (country?.code as CountryCode),
-});
+>): AddressInput => {
+	const formattedPostalCode = postalCode ? postalCode.toUpperCase() : "";
+	return {
+		...pick(rest, getAllAddressFieldKeys()),
+		country: countryCode || (country?.code as CountryCode),
+		postalCode: formattedPostalCode,
+	};
+};
 
 export const getAddressInputDataFromAddress = (
 	address: OptionalAddress | Partial<AddressFragment>,


### PR DESCRIPTION
This pull request adds functionality to the getAddressInputData function within the AddressForm utilities to automatically convert postal code input to uppercase.

Modified getAddressInputData in src/checkout/components/AddressForm/utils.py to capitalize postal codes before form submission. This ensures consistency with backend API requirements and improves user experience by removing case sensitivity issues.
Why this change is needed
The backend API requires postal codes to be in uppercase. Users might enter lowercase postal codes, which results in validation errors that could be confusing. By automatically transforming postal codes to uppercase, we eliminate this friction and potential confusion.
Testing
Manual testing was conducted to ensure the form behaves as expected, and postal codes can transfer to uppercase.
This change resolves issue #1024.