### PR TITLE
Make login fields (email and password) required

### DIFF
--- a/src/ui/components/LoginForm.tsx
+++ b/src/ui/components/LoginForm.tsx
@@ -28,6 +28,7 @@ export async function LoginForm() {
 						Email
 					</label>
 					<input
+						required
 						type="email"
 						name="email"
 						placeholder="Email"
@@ -39,6 +40,7 @@ export async function LoginForm() {
 						Password
 					</label>
 					<input
+						required
 						type="password"
 						name="password"
 						placeholder="Password"


### PR DESCRIPTION
The demo on Vercel (and local setup) crashed when the login form was submitted with empty values. Making the login fields required fixes the issue.