### PR TITLE
Fixed codegen to look for every graphql file

### DIFF
--- a/.graphqlrc.ts
+++ b/.graphqlrc.ts
@@ -20,7 +20,7 @@ if (!schemaUrl) {
 const config: CodegenConfig = {
 	overwrite: true,
 	schema: schemaUrl,
-	documents: "src/graphql/**/*.graphql",
+	documents: "src/**/*.graphql",
 	generates: {
 		"src/gql/": {
 			preset: "client",


### PR DESCRIPTION
Previously storefront GraphQL codegen config was looking for files only in `src/graphql/..` folder, which excluded `src/checkout/graphql/*.graphql` files.

After the change we will simply look for any `.graphql` file in `src` directory
