### PR TITLE
Bugfix .graphqlrc.ts: type Hour

### DIFF
--- a/.graphqlrc.ts
+++ b/.graphqlrc.ts
@@ -30,6 +30,7 @@ const config: CodegenConfig = {
 				useTypeImports: true,
 				strictScalars: true,
 				scalars: {
+					Hour: "string",
 					Date: "string",
 					DateTime: "string",
 					Day: "number",


### PR DESCRIPTION
```node
$ pnpm dev

> saleor-storefront@0.1.0 predev /opt/web/shop/saleor/frontend-npm/saleor-storefront
> pnpm run generate


> saleor-storefront@0.1.0 generate /opt/web/shop/saleor/frontend-npm/saleor-storefront
> graphql-codegen --config .graphqlrc.ts

✔ Parse Configuration
⚠ Generate outputs
  ❯ Generate to src/gql/
    ✔ Load GraphQL schemas
    ✔ Load GraphQL documents
    ✖ Unknown scalar type Hour. Please override it using the "scalars" configuration f…
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
```