### PR TITLE
fix(checkout): broken PayPal logo

### DIFF
--- a/src/checkout/components/payment/payment-method-selector.tsx
+++ b/src/checkout/components/payment/payment-method-selector.tsx
@@ -178,8 +178,10 @@ export const PaymentMethodSelector: FC<PaymentMethodSelectorProps> = ({
 							className="sr-only"
 						/>
 						<RadioIndicator selected={value === "paypal"} />
-						<span className="font-bold text-blue-600">Pay</span>
-						<span className="font-bold text-blue-900">Pal</span>
+						<span>
+							<span className="font-bold text-blue-600">Pay</span>
+							<span className="font-bold text-blue-900">Pal</span>
+						</span>
 					</label>
 				)}
 


### PR DESCRIPTION
The PayPal logo had a 1rem gap between "Pay" and "Pal"

| Before | After
|--|--|
| <img width="769" height="485" alt="Screenshot 2026-03-02 at 16 32 52" src="https://github.com/user-attachments/assets/3a20a02e-b90f-40d0-be90-90538f8f4c88" /> | <img width="770" height="469" alt="Screenshot 2026-03-02 at 16 44 31" src="https://github.com/user-attachments/assets/ede56d91-b231-4008-9f93-636c00c00b94" /> |