### PR TITLE
Restore delayed fade-in on PDP route loading skeleton

### DIFF
--- a/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/loading.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/loading.tsx
@@ -1,7 +1,7 @@
 import { ProductRouteSkeleton } from "@/ui/components/pdp/product-route-skeleton";
 
 /**
- * Product page skeleton — shown immediately on route transitions (Next.js 16.3 instant nav).
+ * Product page skeleton — delayed fade-in on route transitions to avoid flash on fast loads.
  */
 export default function ProductLoading() {
 	return <ProductRouteSkeleton surface="route" />;

--- a/src/ui/components/pdp/product-route-skeleton.tsx
+++ b/src/ui/components/pdp/product-route-skeleton.tsx
@@ -6,10 +6,8 @@ import { VariantSectionSkeleton } from "./variant-section-dynamic";
 interface ProductRouteSkeletonProps {
 	/**
 	 * Where the skeleton renders:
-	 * - `"route"`: route `loading.tsx` during client navigations.
+	 * - `"route"`: route `loading.tsx` during client navigations (delayed fade-in).
 	 * - `"page"`: page-level Suspense fallback while `ProductShell` resolves.
-	 *
-	 * Shown immediately (no fade delay) so 16.3 instant navigations surface a shell on click.
 	 */
 	surface?: "route" | "page";
 }
@@ -50,7 +48,10 @@ function AttributesAccordionSkeleton({ className }: { className?: string }) {
 export function ProductRouteSkeleton({ surface = "page" }: ProductRouteSkeletonProps) {
 	const layout = PDP_LAYOUT_CLASSES[PDP_GALLERY_LAYOUT];
 
-	const wrapperClassName = surface === "page" ? "flex min-h-screen flex-col bg-background" : undefined;
+	const wrapperClassName =
+		surface === "page"
+			? "flex min-h-screen flex-col bg-background"
+			: cn("animate-skeleton-delayed-long", "opacity-0");
 
 	return (
 		<div role="status" aria-busy="true" aria-label="Loading product" className={wrapperClassName}>


### PR DESCRIPTION
On 16.2.9 without partialPrefetching, immediate skeleton visibility flashes on every client navigation to a product. Reapply animate-skeleton-delayed-long for surface="route" only so fast loads stay clean while slow loads still get feedback.