### PR TITLE
fix: simplify Dockerfile and reduce build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 
 # Install dependencies only when needed
-FROM base AS deps
+FROM base AS builder
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -10,66 +10,71 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
-COPY package.json pnpm-lock.yaml ./
+COPY ./.npmrc package.json pnpm-lock.yaml ./
 RUN pnpm i --frozen-lockfile --prefer-offline
 
-# Rebuild the source code only when needed
-FROM base AS builder
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+# Ordered from least likely to most likely to be updated
+COPY \
+    ./global.d.ts \
+    ./knip.config.ts \
+    ./next.config.js \
+    ./paper-version.json \
+    ./postcss.config.cjs \
+    ./tailwind.config.cjs \
+    ./tsconfig.json \
+    ./.graphqlrc.ts \
+    ./
+COPY ./messages ./messages/
+COPY ./public ./public/
+COPY ./src ./src/
 
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-# ENV NEXT_TELEMETRY_DISABLED 1
-
-ENV NEXT_OUTPUT=standalone
-ARG NEXT_PUBLIC_SALEOR_API_URL
-ENV NEXT_PUBLIC_SALEOR_API_URL=${NEXT_PUBLIC_SALEOR_API_URL}
-ARG NEXT_PUBLIC_STOREFRONT_URL
-ENV NEXT_PUBLIC_STOREFRONT_URL=${NEXT_PUBLIC_STOREFRONT_URL}
-ARG NEXT_PUBLIC_DEFAULT_CHANNEL
-ENV NEXT_PUBLIC_DEFAULT_CHANNEL=${NEXT_PUBLIC_DEFAULT_CHANNEL}
-
-# Disable telemetry
+# Disable telemetry (build + runtime)
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Get PNPM version from package.json
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+ARG NEXT_PUBLIC_SALEOR_API_URL
+ENV NEXT_PUBLIC_SALEOR_API_URL=${NEXT_PUBLIC_SALEOR_API_URL}
 
-RUN pnpm build
+ARG NEXT_PUBLIC_STOREFRONT_URL
+ENV NEXT_PUBLIC_STOREFRONT_URL=${NEXT_PUBLIC_STOREFRONT_URL}
+
+ARG NEXT_PUBLIC_DEFAULT_CHANNEL
+ENV NEXT_PUBLIC_DEFAULT_CHANNEL=${NEXT_PUBLIC_DEFAULT_CHANNEL:-default-channel}
+
+ARG NEXT_PUBLIC_ENABLE_STRIPE_PAYMENTS
+ENV NEXT_PUBLIC_ENABLE_STRIPE_PAYMENTS=${NEXT_PUBLIC_ENABLE_STRIPE_PAYMENTS:-false}
+
+# Build Next.js
+RUN NEXT_OUTPUT=standalone \
+    pnpm build
 
 # Production image, copy all the files and run next
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-# Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED 1
-
-ARG NEXT_PUBLIC_SALEOR_API_URL
-ENV NEXT_PUBLIC_SALEOR_API_URL=${NEXT_PUBLIC_SALEOR_API_URL}
-ARG NEXT_PUBLIC_STOREFRONT_URL
-ENV NEXT_PUBLIC_STOREFRONT_URL=${NEXT_PUBLIC_STOREFRONT_URL}
+ENV NODE_ENV=production
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
-
-# COPY --from=builder /app/public ./public
 
 # Set the correct permission for prerender cache
 RUN mkdir .next
 RUN chown nextjs:nodejs .next
 
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
+ARG NEXT_PUBLIC_SALEOR_API_URL
+ENV NEXT_PUBLIC_SALEOR_API_URL=${NEXT_PUBLIC_SALEOR_API_URL}
+
+ARG NEXT_PUBLIC_STOREFRONT_URL
+ENV NEXT_PUBLIC_STOREFRONT_URL=${NEXT_PUBLIC_STOREFRONT_URL}
+
+# Note: takes the value from NEXT_PUBLIC_ENABLE_STRIPE_PAYMENTS as it's only
+# reflecting to the backend server whether the Stripe integration is enabled
+ARG NEXT_PUBLIC_ENABLE_STRIPE_PAYMENTS
+ENV ENABLE_STRIPE_PAYMENTS=${NEXT_PUBLIC_ENABLE_STRIPE_PAYMENTS:-false}
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
- Simplified the Dockerfile by removing unnecessary code
- Reduced build-time & build size by no longer copying the whole git workspace
- Fixed missing `.npmrc`
- Made `NEXT_PUBLIC_DEFAULT_CHANNEL` optional
- Fixed missing support for Stripe payments
- Fixed missing static assets (such as the storefront logo)
- Fixed EOL & mismatching Node.js version - version was EOL, and project expects 24.x (https://github.com/saleor/storefront/blob/24053f247ab9b10b6721439bf500d9e1e6a69f7c/package.json?1#L119)