### PR TITLE
Translatable slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,16 @@ buildCheckoutPath()                  /checkout/complete?order= (confirmation)
 
 ### 🌍 International by Default
 
-One codebase, many markets. Browse URLs are **`/{locale}/{channel}/…`** — e.g. `/en/us/products/hoodie` (English, US market, USD) and `/fr/fr/products/hoodie` (French, France, EUR) — with legacy `/{channel}/…` paths redirecting automatically. Each locale gets its own cached catalog payload, translated product copy from Saleor, per-channel pricing and currency, and hreflang/canonical metadata.
+One codebase, many markets. Browse URLs are **`/{locale}/{channel}/…`** — e.g. `/en/us/products/hoodie` (English, US market, USD) and `/pl/pl/products/bluza` (Polish, Poland, PLN, with a **translated catalog slug** when set in Saleor) — with legacy `/{channel}/…` paths redirecting automatically. Each locale gets its own cached catalog payload, translated product copy from Saleor, per-channel pricing and currency, and hreflang/canonical metadata (including per-locale product/category handles).
 
-- **Region picker** — header control switches locale and channel together (language + market + currency)
+- **Region picker** — header control switches locale and channel together (language + market + currency), remapping catalog URLs to each language’s canonical slug
 - **Three string systems** — Saleor catalog translations, merchant-editable storefront content (CMS), and code-owned UI via **next-intl** (`messages/{locale}.json`)
 - **Six built-in locales** — `en`, `pl`, `de`, `fr`, `fi`, `nb` (extend via `LOCALE_DEFINITIONS` in `src/config/locale.ts`)
+- **Optional translated URL slugs** — Saleor Dashboard can set per-language handles for products, categories, collections, and pages; Paper resolves, redirects, links, and hreflang accordingly ([ADR 0004](docs/adr/0004-translatable-slugs.md))
 
 **Storefront channels are explicit.** Saleor may have many channels (B2B, wholesale, internal regions); Paper only exposes the slugs you configure via `STOREFRONT_CHANNELS`. Disallowed channel URLs return 404. For a single-channel store, set `NEXT_PUBLIC_DEFAULT_CHANNEL` only—the footer channel selector is hidden automatically.
 
-**Developer docs:** [`docs/international-storefront.md`](docs/international-storefront.md) · ADRs [0001](docs/adr/0001-locale-channel-url-routing.md) / [0002](docs/adr/0002-cms-copy-vs-code-owned-ui-strings.md) · skills [`ui-locale-routing`](skills/saleor-paper-storefront/rules/ui-locale-routing.md) / [`ui-i18n`](skills/saleor-paper-storefront/rules/ui-i18n.md)
+**Developer docs:** [`docs/international-storefront.md`](docs/international-storefront.md) · ADRs [0001](docs/adr/0001-locale-channel-url-routing.md) / [0002](docs/adr/0002-cms-copy-vs-code-owned-ui-strings.md) / [0004](docs/adr/0004-translatable-slugs.md) · skills [`ui-locale-routing`](skills/saleor-paper-storefront/rules/ui-locale-routing.md) / [`ui-i18n`](skills/saleor-paper-storefront/rules/ui-i18n.md)
 
 ### 📱 Product Pages Done Right
 
@@ -103,21 +104,21 @@ Whether you're pair-programming with Cursor, Claude, or Copilot—the codebase i
 
 ## What's in the Box
 
-| Feature                    | Description                                                                                         |
-| -------------------------- | --------------------------------------------------------------------------------------------------- |
-| **Checkout (v2)**          | RSC + server actions, shallow step URLs, payment registry (Stripe/Dummy), `/checkout/complete`      |
-| **Cart**                   | Slide-over drawer with real-time updates, quantity editing                                          |
-| **Product Pages**          | Multi-attribute variants, image gallery, sticky add-to-cart                                         |
-| **Product Listings**       | Category & collection pages with PPR (cached hero + dynamic filters), pagination                    |
-| **International**          | `/{locale}/{channel}/` routing, region picker, Saleor translations, next-intl UI, hreflang SEO      |
-| **Storefront content**     | Merchant-editable copy layer (code or Saleor Models) — homepage, cart trust, checkout editorial     |
-| **Navigation**             | Dynamic menus from Saleor, mobile hamburger, breadcrumbs                                            |
-| **SEO**                    | Per-locale metadata, JSON-LD, Open Graph images, hreflang alternates                                |
-| **Caching**                | Cache Components (PPR), named cacheLife tiers, per-locale catalog cache, webhooks                   |
-| **Saleor Cloud Paper app** | Saleor Cloud only — Dashboard extension for cache invalidation webhooks and _Preview in storefront_ |
-| **Customer Profile**       | Account dashboard, address book, order history, password change, account deletion                   |
-| **Authentication**         | Login, register, password reset, guest checkout                                                     |
-| **API Resilience**         | Automatic retries, rate limiting, timeouts—handles flaky connections gracefully                     |
+| Feature                    | Description                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Checkout (v2)**          | RSC + server actions, shallow step URLs, payment registry (Stripe/Dummy), `/checkout/complete`                                 |
+| **Cart**                   | Slide-over drawer with real-time updates, quantity editing                                                                     |
+| **Product Pages**          | Multi-attribute variants, image gallery, sticky add-to-cart                                                                    |
+| **Product Listings**       | Category & collection pages with PPR (cached hero + dynamic filters), pagination                                               |
+| **International**          | `/{locale}/{channel}/` routing, region picker, Saleor translations + optional translated URL slugs, next-intl UI, hreflang SEO |
+| **Storefront content**     | Merchant-editable copy layer (code or Saleor Models) — homepage, cart trust, checkout editorial                                |
+| **Navigation**             | Dynamic menus from Saleor, mobile hamburger, breadcrumbs                                                                       |
+| **SEO**                    | Per-locale metadata, JSON-LD, Open Graph images, hreflang with per-locale catalog handles                                      |
+| **Caching**                | Cache Components (PPR), named cacheLife tiers, per-locale catalog cache, webhooks                                              |
+| **Saleor Cloud Paper app** | Saleor Cloud only — Dashboard extension for cache invalidation webhooks and _Preview in storefront_                            |
+| **Customer Profile**       | Account dashboard, address book, order history, password change, account deletion                                              |
+| **Authentication**         | Login, register, password reset, guest checkout                                                                                |
+| **API Resilience**         | Automatic retries, rate limiting, timeouts—handles flaky connections gracefully                                                |
 
 ---
 

--- a/docs/adr/0004-translatable-slugs.md
+++ b/docs/adr/0004-translatable-slugs.md
@@ -34,14 +34,16 @@ Support translated slugs as an **opt-in merchant capability**. When a translatio
 4. **Cache tags** — always tag with the **primary** slug (webhook identity). When the URL slug differs, also tag with the URL slug so either form invalidates.
 5. **Link generation** — cards, menus, breadcrumbs, JSON-LD, and metadata path suffixes use `pickTranslatedSlug`.
 6. **Filters / search** — keep using primary slugs (API limitation).
+7. **Language switch** — region picker rewrites catalog detail suffixes to the **primary** slug (via `CatalogIdentityBridge`), preserves query string, then the target locale’s server resolve + rule 3 308 to that locale’s canonical slug. Never keep a foreign-language handle in the path.
 
 ### Phased delivery
 
-| Phase | Scope                                                                                        | Status      |
-| ----- | -------------------------------------------------------------------------------------------- | ----------- |
-| **1** | Resolve + fallback + dual cache tags + canonical redirect + link fields on catalog/menus/PLP | This branch |
-| **2** | Per-locale hreflang / sitemap path suffixes (needs all locale slugs in one metadata fetch)   | Follow-up   |
-| **3** | `TRANSLATION_*` webhook handling in `/api/revalidate`                                        | Follow-up   |
+| Phase  | Scope                                                                                        | Status      |
+| ------ | -------------------------------------------------------------------------------------------- | ----------- |
+| **1**  | Resolve + fallback + dual cache tags + canonical redirect + link fields on catalog/menus/PLP | Shipped     |
+| **1b** | Language switch via primary slug + query preserve (`CatalogIdentityBridge`)                  | This change |
+| **2**  | Per-locale hreflang / sitemap path suffixes (needs all locale slugs in one metadata fetch)   | Follow-up   |
+| **3**  | `TRANSLATION_*` webhook handling in `/api/revalidate`                                        | Follow-up   |
 
 ### Merge note (Next.js 16.3 preview)
 

--- a/docs/adr/0004-translatable-slugs.md
+++ b/docs/adr/0004-translatable-slugs.md
@@ -1,0 +1,64 @@
+# ADR 0004: Saleor translatable catalog slugs
+
+**Status:** Accepted (phase 1 in progress)  
+**Date:** 2026-07-21  
+**Deciders:** Paper storefront team  
+**Related:** [0001 Locale and channel URL routing](./0001-locale-channel-url-routing.md)
+
+## Context
+
+Saleor (since 3.21) lets merchants translate **URL slugs** for Product, Category, Collection, and Page. Translations store an optional `slug` per `language_code`, unique within `(language_code, slug)` per entity type. Single-object queries accept `slugLanguageCode`:
+
+```graphql
+product(slug: "bluza", channel: "pl", slugLanguageCode: PL) { … }
+```
+
+Important API constraints (verified in Saleor source):
+
+- **No automatic fallback** — translated lookup and primary lookup are exclusive; the client must try both.
+- **Lookup-only** — list filters (`slugs: […]`), search, and `where` match **primary** slugs only.
+- **Optional per entity** — a locale may translate names without translating the slug.
+- **Webhooks** — `TRANSLATION_CREATED` / `TRANSLATION_UPDATED` fire on slug edits; `PRODUCT_UPDATED` does not.
+
+Paper already routes as `/{locale}/{channel}/…` and merges display translations (`name`, SEO, …) but always resolves and links by the **primary** slug. That blocks localized SEO URLs.
+
+## Decision
+
+Support translated slugs as an **opt-in merchant capability**. When a translation slug is absent, behavior stays identical to today (primary slug in every locale).
+
+### Rules
+
+1. **Primary `slug` remains identity** — GraphQL `entity.slug` is never overwritten; URLs use `translation.slug ?? slug` via `pickTranslatedSlug`.
+2. **Resolve with ordered fallback** (every locale): try `slugLanguageCode` first, then primary slug. Link helpers may emit a translated slug on the default locale too, so skipping that lookup would 404.
+3. **Canonical redirect** — if the URL slug is not the canonical slug for that locale, `308`/`permanentRedirect` to the translated (or primary) canonical path.
+4. **Cache tags** — always tag with the **primary** slug (webhook identity). When the URL slug differs, also tag with the URL slug so either form invalidates.
+5. **Link generation** — cards, menus, breadcrumbs, JSON-LD, and metadata path suffixes use `pickTranslatedSlug`.
+6. **Filters / search** — keep using primary slugs (API limitation).
+
+### Phased delivery
+
+| Phase | Scope                                                                                        | Status      |
+| ----- | -------------------------------------------------------------------------------------------- | ----------- |
+| **1** | Resolve + fallback + dual cache tags + canonical redirect + link fields on catalog/menus/PLP | This branch |
+| **2** | Per-locale hreflang / sitemap path suffixes (needs all locale slugs in one metadata fetch)   | Follow-up   |
+| **3** | `TRANSLATION_*` webhook handling in `/api/revalidate`                                        | Follow-up   |
+
+### Merge note (Next.js 16.3 preview)
+
+This work targets `main` and should cherry-pick/merge cleanly into `feat/nextjs-16.3-preview`. Avoid structural edits to `cache-manifest.ts` (that file already drifts on 16.3); dual-tagging uses existing `buildTag` + `cacheTag` at call sites.
+
+## Alternatives considered
+
+| Option                                          | Rejected because                                                                     |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Always URL = primary slug                       | Leaves Saleor's translated-slug feature unused; weak local SEO                       |
+| Overwrite `entity.slug` with translation        | Breaks cache tags and webhook identity                                               |
+| Single query without `slugLanguageCode` retry   | API has no fallback; translated URLs 404                                             |
+| Full hreflang + translation webhooks in phase 1 | Larger blast radius; hreflang needs multi-locale slug fetch not required for resolve |
+
+## Consequences
+
+- Non-default locales (and the default locale when a translation slug exists) may issue **two** GraphQL lookups on cold primary-slug URLs (then redirect). After links emit translated slugs, the common path is one lookup.
+- Merchants who never set translation slugs see no URL change.
+- Until phase 2, `hreflang` alternates may still share one path suffix across locales (canonical URL for the current locale is correct).
+- Until phase 3, editing only a translation slug may leave stale cache until TTL or a product/category update webhook.

--- a/docs/adr/0004-translatable-slugs.md
+++ b/docs/adr/0004-translatable-slugs.md
@@ -62,5 +62,6 @@ This work targets `main` and should cherry-pick/merge cleanly into `feat/nextjs-
 
 - Non-default locales (and the default locale when a translation slug exists) may issue **two** GraphQL lookups on cold primary-slug URLs (then redirect). After links emit translated slugs, the common path is one lookup.
 - Merchants who never set translation slugs see no URL change.
-- hreflang alternates use per-locale path suffixes from `*LocaleSlugTranslations` aliases (`buildLocaleSlugMap`). Language switch prefers those slugs for a zero-hop navigation; primary-slug + 308 remains the fallback.
+- hreflang alternates use per-locale path suffixes from `*LocaleSlugTranslations` aliases (`buildLocaleSlugMap`). Language switch prefers those slugs for a zero-hop navigation; primary-slug + 308 remains the fallback. If identity is not registered yet (chrome before detail shell), language switch drops the foreign handle to `/products` or home instead of 404ing.
+- Webhook `revalidatePath` fan-out still uses the **primary** slug; dual `cacheTag` (URL + primary) covers `"use cache"` data. Explicit path revalidation of every translated URL waits on phase 3 (paper-app can forward locale slug maps) or TTL.
 - Until phase 3 (paper-app `TRANSLATION_*` forwarding), editing only a translation slug may leave stale cache until TTL or a product/category update webhook.

--- a/docs/adr/0004-translatable-slugs.md
+++ b/docs/adr/0004-translatable-slugs.md
@@ -1,6 +1,6 @@
 # ADR 0004: Saleor translatable catalog slugs
 
-**Status:** Accepted (phase 1 in progress)  
+**Status:** Accepted (phases 1–2 shipped)  
 **Date:** 2026-07-21  
 **Deciders:** Paper storefront team  
 **Related:** [0001 Locale and channel URL routing](./0001-locale-channel-url-routing.md)
@@ -34,15 +34,15 @@ Support translated slugs as an **opt-in merchant capability**. When a translatio
 4. **Cache tags** — always tag with the **primary** slug (webhook identity). When the URL slug differs, also tag with the URL slug so either form invalidates.
 5. **Link generation** — cards, menus, breadcrumbs, JSON-LD, and metadata path suffixes use `pickTranslatedSlug`.
 6. **Filters / search** — keep using primary slugs (API limitation).
-7. **Language switch** — region picker rewrites catalog detail suffixes to the **primary** slug (via `CatalogIdentityBridge`), preserves query string, then the target locale’s server resolve + rule 3 308 to that locale’s canonical slug. Never keep a foreign-language handle in the path.
+7. **Language switch** — region picker rewrites catalog detail suffixes using the **target locale’s canonical slug** from `localeSlugs` when available (zero hop); otherwise the **primary** slug with server 308. Preserves query string. Never keep a foreign-language handle in the path.
 
 ### Phased delivery
 
 | Phase  | Scope                                                                                        | Status      |
 | ------ | -------------------------------------------------------------------------------------------- | ----------- |
 | **1**  | Resolve + fallback + dual cache tags + canonical redirect + link fields on catalog/menus/PLP | Shipped     |
-| **1b** | Language switch via primary slug + query preserve (`CatalogIdentityBridge`)                  | This change |
-| **2**  | Per-locale hreflang / sitemap path suffixes (needs all locale slugs in one metadata fetch)   | Follow-up   |
+| **1b** | Language switch via primary slug + query preserve (`CatalogIdentityBridge`)                  | Shipped     |
+| **2**  | Per-locale hreflang path suffixes + zero-hop language switch from locale slug map            | This change |
 | **3**  | `TRANSLATION_*` webhook handling in `/api/revalidate`                                        | Follow-up   |
 
 ### Merge note (Next.js 16.3 preview)
@@ -62,5 +62,5 @@ This work targets `main` and should cherry-pick/merge cleanly into `feat/nextjs-
 
 - Non-default locales (and the default locale when a translation slug exists) may issue **two** GraphQL lookups on cold primary-slug URLs (then redirect). After links emit translated slugs, the common path is one lookup.
 - Merchants who never set translation slugs see no URL change.
-- Until phase 2, `hreflang` alternates may still share one path suffix across locales (canonical URL for the current locale is correct).
+- hreflang alternates use per-locale path suffixes from `*LocaleSlugTranslations` aliases (`buildLocaleSlugMap`). Language switch prefers those slugs for a zero-hop navigation; primary-slug + 308 remains the fallback.
 - Until phase 3, editing only a translation slug may leave stale cache until TTL or a product/category update webhook.

--- a/docs/adr/0004-translatable-slugs.md
+++ b/docs/adr/0004-translatable-slugs.md
@@ -38,12 +38,12 @@ Support translated slugs as an **opt-in merchant capability**. When a translatio
 
 ### Phased delivery
 
-| Phase  | Scope                                                                                        | Status      |
-| ------ | -------------------------------------------------------------------------------------------- | ----------- |
-| **1**  | Resolve + fallback + dual cache tags + canonical redirect + link fields on catalog/menus/PLP | Shipped     |
-| **1b** | Language switch via primary slug + query preserve (`CatalogIdentityBridge`)                  | Shipped     |
-| **2**  | Per-locale hreflang path suffixes + zero-hop language switch from locale slug map            | This change |
-| **3**  | `TRANSLATION_*` webhook handling in `/api/revalidate`                                        | Follow-up   |
+| Phase  | Scope                                                                                        | Status                                                                                                                                                                                                                   |
+| ------ | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **1**  | Resolve + fallback + dual cache tags + canonical redirect + link fields on catalog/menus/PLP | Shipped                                                                                                                                                                                                                  |
+| **1b** | Language switch via primary slug + query preserve (`CatalogIdentityBridge`)                  | Shipped                                                                                                                                                                                                                  |
+| **2**  | Per-locale hreflang path suffixes + zero-hop language switch from locale slug map            | Shipped                                                                                                                                                                                                                  |
+| **3**  | `TRANSLATION_*` webhook → invalidate catalog caches                                          | Follow-up — **primarily [saleor-paper-app](https://github.com/saleor/saleor-paper-app)** (subscribe + map to parent primary slug + forward to `/api/revalidate`). Storefront only if payload shape needs a thin adapter. |
 
 ### Merge note (Next.js 16.3 preview)
 
@@ -63,4 +63,4 @@ This work targets `main` and should cherry-pick/merge cleanly into `feat/nextjs-
 - Non-default locales (and the default locale when a translation slug exists) may issue **two** GraphQL lookups on cold primary-slug URLs (then redirect). After links emit translated slugs, the common path is one lookup.
 - Merchants who never set translation slugs see no URL change.
 - hreflang alternates use per-locale path suffixes from `*LocaleSlugTranslations` aliases (`buildLocaleSlugMap`). Language switch prefers those slugs for a zero-hop navigation; primary-slug + 308 remains the fallback.
-- Until phase 3, editing only a translation slug may leave stale cache until TTL or a product/category update webhook.
+- Until phase 3 (paper-app `TRANSLATION_*` forwarding), editing only a translation slug may leave stale cache until TTL or a product/category update webhook.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,11 +2,11 @@
 
 Informal north-star for day-to-day conventions: [`skills/saleor-paper-storefront/rules/paper-architecture.md`](../skills/saleor-paper-storefront/rules/paper-architecture.md). File naming and imports: [`code-conventions.md`](../skills/saleor-paper-storefront/references/code-conventions.md).
 
-| ADR                                                 | Title                                                   | Status                         |
-| --------------------------------------------------- | ------------------------------------------------------- | ------------------------------ |
-| [0001](./0001-locale-channel-url-routing.md)        | Locale and channel URL routing (`/{locale}/{channel}/`) | Accepted (implemented)         |
-| [0002](./0002-cms-copy-vs-code-owned-ui-strings.md) | CMS editorial copy vs code-owned UI strings (next-intl) | Accepted (implemented)         |
-| [0003](./0003-executable-checks-in-agent-loop.md)   | Executable checks in the agent's feedback loop          | Accepted (implemented)         |
-| [0004](./0004-translatable-slugs.md)                | Saleor translatable catalog slugs                       | Accepted (phase 1 in progress) |
+| ADR                                                 | Title                                                   | Status                        |
+| --------------------------------------------------- | ------------------------------------------------------- | ----------------------------- |
+| [0001](./0001-locale-channel-url-routing.md)        | Locale and channel URL routing (`/{locale}/{channel}/`) | Accepted (implemented)        |
+| [0002](./0002-cms-copy-vs-code-owned-ui-strings.md) | CMS editorial copy vs code-owned UI strings (next-intl) | Accepted (implemented)        |
+| [0003](./0003-executable-checks-in-agent-loop.md)   | Executable checks in the agent's feedback loop          | Accepted (implemented)        |
+| [0004](./0004-translatable-slugs.md)                | Saleor translatable catalog slugs                       | Accepted (phases 1–2 shipped) |
 
 **Human overview:** [`docs/international-storefront.md`](../international-storefront.md) — how routing, Saleor translations, CMS copy, and `messages/*.json` fit together.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,9 +2,11 @@
 
 Informal north-star for day-to-day conventions: [`skills/saleor-paper-storefront/rules/paper-architecture.md`](../skills/saleor-paper-storefront/rules/paper-architecture.md). File naming and imports: [`code-conventions.md`](../skills/saleor-paper-storefront/references/code-conventions.md).
 
-| ADR                                                 | Title                                                   | Status                 |
-| --------------------------------------------------- | ------------------------------------------------------- | ---------------------- |
-| [0001](./0001-locale-channel-url-routing.md)        | Locale and channel URL routing (`/{locale}/{channel}/`) | Accepted (implemented) |
-| [0002](./0002-cms-copy-vs-code-owned-ui-strings.md) | CMS editorial copy vs code-owned UI strings (next-intl) | Accepted (implemented) |
+| ADR                                                 | Title                                                   | Status                         |
+| --------------------------------------------------- | ------------------------------------------------------- | ------------------------------ |
+| [0001](./0001-locale-channel-url-routing.md)        | Locale and channel URL routing (`/{locale}/{channel}/`) | Accepted (implemented)         |
+| [0002](./0002-cms-copy-vs-code-owned-ui-strings.md) | CMS editorial copy vs code-owned UI strings (next-intl) | Accepted (implemented)         |
+| [0003](./0003-executable-checks-in-agent-loop.md)   | Executable checks in the agent's feedback loop          | Accepted (implemented)         |
+| [0004](./0004-translatable-slugs.md)                | Saleor translatable catalog slugs                       | Accepted (phase 1 in progress) |
 
 **Human overview:** [`docs/international-storefront.md`](../international-storefront.md) — how routing, Saleor translations, CMS copy, and `messages/*.json` fit together.

--- a/docs/international-storefront.md
+++ b/docs/international-storefront.md
@@ -2,9 +2,9 @@
 
 How Paper serves **multiple languages and markets** from one deployment. Start here before adding a locale, wiring copy, or debugging “wrong language” bugs.
 
-**ADRs:** [0001 Locale + channel routing](./adr/0001-locale-channel-url-routing.md) · [0002 CMS vs code-owned strings](./adr/0002-cms-copy-vs-code-owned-ui-strings.md)
+**ADRs:** [0001 Locale + channel routing](./adr/0001-locale-channel-url-routing.md) · [0002 CMS vs code-owned strings](./adr/0002-cms-copy-vs-code-owned-ui-strings.md) · [0004 Translatable catalog slugs](./adr/0004-translatable-slugs.md)
 
-**Skills:** [`ui-locale-routing`](../skills/saleor-paper-storefront/rules/ui-locale-routing.md) · [`ui-i18n`](../skills/saleor-paper-storefront/rules/ui-i18n.md) · [`data-storefront-content`](../skills/saleor-paper-storefront/rules/data-storefront-content.md)
+**Skills:** [`ui-locale-routing`](../skills/saleor-paper-storefront/rules/ui-locale-routing.md) · [`ui-i18n`](../skills/saleor-paper-storefront/rules/ui-i18n.md) · [`seo-metadata`](../skills/saleor-paper-storefront/rules/seo-metadata.md) · [`data-storefront-content`](../skills/saleor-paper-storefront/rules/data-storefront-content.md)
 
 ---
 
@@ -12,11 +12,13 @@ How Paper serves **multiple languages and markets** from one deployment. Start h
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│  URL: /{locale}/{channel}/products/hoodie                               │
+│  URL: /{locale}/{channel}/products/{slug}                               │
+│       e.g. /en/us/products/hoodie  ·  /pl/pl/products/bluza             │
 ├─────────────────────────────────────────────────────────────────────────┤
 │                                                                         │
 │  1. Saleor catalog translations (GraphQL languageCode)                    │
 │     Product names, attributes, menus, categories                        │
+│     Optional translated URL slugs (ADR 0004) — pickTranslatedSlug()     │
 │     → pickTranslatedName(), translation { } fields                      │
 │                                                                         │
 │  2. Storefront content layer (CMS / Saleor Models)                      │
@@ -31,7 +33,7 @@ How Paper serves **multiple languages and markets** from one deployment. Start h
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Decision rule (ADR 0002):** _Would a merchant reword this per shop for brand voice?_ → CMS (2). Otherwise → `messages/*.json` (3). Product/category **names** always come from Saleor (1).
+**Decision rule (ADR 0002):** _Would a merchant reword this per shop for brand voice?_ → CMS (2). Otherwise → `messages/*.json` (3). Product/category **names** always come from Saleor (1). Catalog **URL handles** may also be translated in Saleor (1) when merchants set translation slugs.
 
 **Channel policies** (`freeShippingThreshold`, `returnsWindowDays`) are structured **facts** in the content layer—not strings in any of the three buckets. Copy references them via `{freeShippingThreshold}` tokens.
 
@@ -48,15 +50,28 @@ Browse: `/{locale}/{channel}/{path}`
 
 ```
 /en/us/products/hoodie     English UI, US market (USD)
-/fr/fr/products/hoodie     French UI, France market (EUR)
+/pl/pl/products/bluza      Polish UI, Poland (PLN) — translated product slug when set in Saleor
 /en/uk/products/hoodie     English UI, UK market (GBP) — same language, different channel
 ```
 
 Checkout stays at `/checkout` — locale and channel sync from browse via cookies (see ADR 0001).
 
-**Region picker** (header): swap language or market; preserve path suffix. Optional `NEXT_PUBLIC_STOREFRONT_LOCALE_CHANNELS` restricts valid pairs.
+**Region picker** (header/footer): swap language or market; on catalog detail pages, remap to that locale’s canonical product/category/page slug (ADR 0004). Optional `NEXT_PUBLIC_STOREFRONT_LOCALE_CHANNELS` restricts valid pairs.
 
-Legacy `/{channel}/…` URLs **308** to `/{defaultLocale}/{channel}/…` via middleware.
+**Structural path segments** (`/products/`, `/categories/`, …) stay English in code — only Saleor entity slugs are translatable. Legacy `/{channel}/…` URLs **308** to `/{defaultLocale}/{channel}/…` via middleware.
+
+### Translated catalog slugs (optional)
+
+Saleor (3.21+) can store a per-language `translation.slug` for products, categories, collections, and pages. Paper:
+
+1. Resolves URLs with `slugLanguageCode`, then falls back to the primary slug
+2. **308**s non-canonical handles to the locale’s canonical slug
+3. Builds links, menus, and **hreflang** with `pickTranslatedSlug` / `buildLocaleSlugMap`
+4. Remaps the handle on language switch (or drops to `/products` / home if identity is not ready yet)
+
+Primary `entity.slug` remains cache/webhook identity. Details: [ADR 0004](./adr/0004-translatable-slugs.md).
+
+Merchants who never set translation slugs keep shared handles across locales (previous behavior).
 
 ---
 
@@ -127,7 +142,7 @@ Configurator ops: [`config/saleor/README.md`](../config/saleor/README.md).
 - **Cache keys** include `localeSlug` — separate cached GraphQL payload per language, same TTL.
 - **Cache tags** stay slug-scoped (`product:{slug}`); webhooks fan out paths across locales via `buildPathsForAllLocales()`.
 - **Storefront content** tag: `storefront-content:{channel}:{locale}` (BCP 47).
-- **Canonical + hreflang** on browse pages — `buildBrowsePageMetadata()`.
+- **Canonical + hreflang** on browse pages — `buildBrowsePageMetadata()`; catalog detail pages pass `pathSuffixByLocale` so each language’s alternate uses its own handle.
 - **`<html lang>`** set server-side from URL locale.
 
 Details: [`data-caching.md`](../skills/saleor-paper-storefront/rules/data-caching.md) § Locale · [`seo-metadata.md`](../skills/saleor-paper-storefront/rules/seo-metadata.md).
@@ -139,20 +154,23 @@ Details: [`data-caching.md`](../skills/saleor-paper-storefront/rules/data-cachin
 1. **`src/config/locale.ts`** — add slug to `LOCALE_DEFINITIONS` (bcp47, graphqlLanguageCode, htmlLang).
 2. **`messages/{slug}.json`** — copy structure from `en.json`; translate all keys.
 3. **`NEXT_PUBLIC_STOREFRONT_LOCALES`** — include the new slug.
-4. **Saleor Dashboard** — translate products, categories, menus, attributes for that language.
+4. **Saleor Dashboard** — translate products, categories, menus, attributes for that language; optionally set **translated URL slugs** (Translations → slug) for SEO handles.
 5. **If `CONTENT_PROVIDER=saleor`:** add `config/saleor/fixtures/translations/{slug}.yaml` and run `pnpm configurator:storefront-content:translations`.
-6. **Verify:** browse URL, product name translation, cart/checkout handoff, hreflang alternates, region picker.
+6. **If adding a locale to `LOCALE_DEFINITIONS`:** also add `slugXX` aliases in `src/graphql/LocaleSlugTranslations.graphql` (keep in sync with `graphqlLanguageCode`).
+7. **Verify:** browse URL, product name translation, translated-slug URL + language switch, cart/checkout handoff, hreflang alternates, region picker.
 
 ---
 
 ## Backlog (known gaps)
 
-| Item                                 | Notes                                                  |
-| ------------------------------------ | ------------------------------------------------------ |
-| Checkout contact/auth/address/Stripe | Done — server-action fallbacks + gateway alerts remain |
-| `not-found` / global error pages     | English                                                |
-| PLP price filter labels              | Hardcoded USD ranges                                   |
-| GraphQL error `message` pass-through | Some account/auth API errors stay API language         |
+| Item                                 | Notes                                                                 |
+| ------------------------------------ | --------------------------------------------------------------------- |
+| Checkout contact/auth/address/Stripe | Done — server-action fallbacks + gateway alerts remain                |
+| `not-found` / global error pages     | English                                                               |
+| PLP price filter labels              | Hardcoded USD ranges                                                  |
+| GraphQL error `message` pass-through | Some account/auth API errors stay API language                        |
+| `TRANSLATION_*` cache invalidation   | Primarily saleor-paper-app (ADR 0004 phase 3)                         |
+| Localized `/products/` path segments | Not planned — structural segments stay English; entity slugs optional |
 
 ---
 

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -3478,7 +3478,7 @@ Browse performance is unchanged after locale routing — locale is part of the *
 
 **GraphQL:** Map URL slugs to Saleor **base** language codes in `src/config/locale.ts` (`pl` → `PL`, not `PL_PL`). Merge `translation { … }` fields after fetch (`src/lib/saleor-translations.ts`).
 
-**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. See `docs/adr/0004-translatable-slugs.md`.
+**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. Language switch rewrites to the primary slug (`CatalogIdentityBridge`) so the target locale can canonical-redirect — never keep a foreign-language handle. See `docs/adr/0004-translatable-slugs.md`.
 
 **Invalidation:** Product update → `revalidateTag("product:{slug}")` → busts EN/PL/DE cached entries → `revalidatePath` for every `/{locale}/{channel}/products/{slug}`.
 
@@ -3524,7 +3524,8 @@ Run **301** from old URLs for at least one release.
 ❌ **Hardcoding `EN_US` / `PL_PL` in `graphqlLanguageCode`** — Dashboard translations use base codes (`EN`, `PL`); see `src/config/locale.ts`  
 ❌ **Omitting `localeSlug` from cached fetches** — All locales would share one cache entry and wrong language  
 ❌ **Overwriting `entity.slug` with the translation** — Breaks cache tags / webhooks; use `pickTranslatedSlug` for URLs only  
-❌ **Assuming Saleor falls back between primary and translated slug lookups** — Client must try both (`resolveByPossiblyTranslatedSlug`)
+❌ **Assuming Saleor falls back between primary and translated slug lookups** — Client must try both (`resolveByPossiblyTranslatedSlug`)  
+❌ **Keeping a translated slug when switching locale** — Foreign-language handles 404; rewrite to primary slug via `CatalogIdentityBridge`
 
 ---
 

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -3478,7 +3478,7 @@ Browse performance is unchanged after locale routing — locale is part of the *
 
 **GraphQL:** Map URL slugs to Saleor **base** language codes in `src/config/locale.ts` (`pl` → `PL`, not `PL_PL`). Merge `translation { … }` fields after fetch (`src/lib/saleor-translations.ts`).
 
-**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. Language switch rewrites to the primary slug (`CatalogIdentityBridge`) so the target locale can canonical-redirect — never keep a foreign-language handle. See `docs/adr/0004-translatable-slugs.md`.
+**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. Fetch all locale handles via `*LocaleSlugTranslations` aliases (`buildLocaleSlugMap`) for hreflang and zero-hop language switching. See `docs/adr/0004-translatable-slugs.md`.
 
 **Invalidation:** Product update → `revalidateTag("product:{slug}")` → busts EN/PL/DE cached entries → `revalidatePath` for every `/{locale}/{channel}/products/{slug}`.
 
@@ -3823,19 +3823,23 @@ export default async function ProductPage({ params }) {
 
 Browse canonical URLs include locale and channel: `/{locale}/{channel}/…` (see `docs/adr/0001-locale-channel-url-routing.md`, `ui-locale-routing.md`).
 
-- Use `buildBrowsePageMetadata()` for catalog/CMS pages — sets canonical + `hreflang` alternates (same channel, each configured locale).
-- `generateMetadata` `pathSuffix` is the path after locale/channel, e.g. `/products/${slug}`.
+- Use `buildBrowsePageMetadata()` for catalog/CMS pages — sets canonical + `hreflang` alternates.
+- `generateMetadata` `pathSuffix` is the path after locale/channel for **this** locale, e.g. `/products/${pickTranslatedSlug(product)}`.
+- For translated catalog slugs (ADR 0004), also pass `pathSuffixByLocale` from `buildCatalogPathSuffixByLocale` / `buildLocaleSlugMap` so each `hreflang` points at that language’s handle.
 - `<html lang>` is rendered server-side by the storefront root layout (`(storefront)/[locale]/layout.tsx`), derived from the URL locale segment — no client patching.
 
 ```typescript
 import { buildBrowsePageMetadata } from "@/lib/seo";
+import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "@/lib/catalog/locale-slugs";
+import { catalogPathSuffix } from "@/lib/catalog/canonical-slug";
 
 return buildBrowsePageMetadata({
 	title: category.name,
 	description: category.seoDescription,
 	locale: params.locale,
 	channel: params.channel,
-	pathSuffix: `/categories/${params.slug}`,
+	pathSuffix: catalogPathSuffix("categories", category),
+	pathSuffixByLocale: buildCatalogPathSuffixByLocale("categories", buildLocaleSlugMap(category)),
 });
 ```
 

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -3478,6 +3478,8 @@ Browse performance is unchanged after locale routing — locale is part of the *
 
 **GraphQL:** Map URL slugs to Saleor **base** language codes in `src/config/locale.ts` (`pl` → `PL`, not `PL_PL`). Merge `translation { … }` fields after fetch (`src/lib/saleor-translations.ts`).
 
+**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. See `docs/adr/0004-translatable-slugs.md`.
+
 **Invalidation:** Product update → `revalidateTag("product:{slug}")` → busts EN/PL/DE cached entries → `revalidatePath` for every `/{locale}/{channel}/products/{slug}`.
 
 Full detail: `data-caching.md` § Locale & Caching.
@@ -3520,7 +3522,9 @@ Run **301** from old URLs for at least one release.
 ❌ **Putting locale after channel** (`/uk/en/…`) — conflicts with this ADR  
 ❌ **Implementing `[locale]` routes** before ADR helpers and redirect plan exist  
 ❌ **Hardcoding `EN_US` / `PL_PL` in `graphqlLanguageCode`** — Dashboard translations use base codes (`EN`, `PL`); see `src/config/locale.ts`  
-❌ **Omitting `localeSlug` from cached fetches** — All locales would share one cache entry and wrong language
+❌ **Omitting `localeSlug` from cached fetches** — All locales would share one cache entry and wrong language  
+❌ **Overwriting `entity.slug` with the translation** — Breaks cache tags / webhooks; use `pickTranslatedSlug` for URLs only  
+❌ **Assuming Saleor falls back between primary and translated slug lookups** — Client must try both (`resolveByPossiblyTranslatedSlug`)
 
 ---
 

--- a/skills/saleor-paper-storefront/rules/seo-metadata.md
+++ b/skills/saleor-paper-storefront/rules/seo-metadata.md
@@ -140,19 +140,23 @@ export default async function ProductPage({ params }) {
 
 Browse canonical URLs include locale and channel: `/{locale}/{channel}/…` (see `docs/adr/0001-locale-channel-url-routing.md`, `ui-locale-routing.md`).
 
-- Use `buildBrowsePageMetadata()` for catalog/CMS pages — sets canonical + `hreflang` alternates (same channel, each configured locale).
-- `generateMetadata` `pathSuffix` is the path after locale/channel, e.g. `/products/${slug}`.
+- Use `buildBrowsePageMetadata()` for catalog/CMS pages — sets canonical + `hreflang` alternates.
+- `generateMetadata` `pathSuffix` is the path after locale/channel for **this** locale, e.g. `/products/${pickTranslatedSlug(product)}`.
+- For translated catalog slugs (ADR 0004), also pass `pathSuffixByLocale` from `buildCatalogPathSuffixByLocale` / `buildLocaleSlugMap` so each `hreflang` points at that language’s handle.
 - `<html lang>` is rendered server-side by the storefront root layout (`(storefront)/[locale]/layout.tsx`), derived from the URL locale segment — no client patching.
 
 ```typescript
 import { buildBrowsePageMetadata } from "@/lib/seo";
+import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "@/lib/catalog/locale-slugs";
+import { catalogPathSuffix } from "@/lib/catalog/canonical-slug";
 
 return buildBrowsePageMetadata({
 	title: category.name,
 	description: category.seoDescription,
 	locale: params.locale,
 	channel: params.channel,
-	pathSuffix: `/categories/${params.slug}`,
+	pathSuffix: catalogPathSuffix("categories", category),
+	pathSuffixByLocale: buildCatalogPathSuffixByLocale("categories", buildLocaleSlugMap(category)),
 });
 ```
 

--- a/skills/saleor-paper-storefront/rules/ui-locale-routing.md
+++ b/skills/saleor-paper-storefront/rules/ui-locale-routing.md
@@ -82,7 +82,7 @@ Browse performance is unchanged after locale routing — locale is part of the *
 
 **GraphQL:** Map URL slugs to Saleor **base** language codes in `src/config/locale.ts` (`pl` → `PL`, not `PL_PL`). Merge `translation { … }` fields after fetch (`src/lib/saleor-translations.ts`).
 
-**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. See `docs/adr/0004-translatable-slugs.md`.
+**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. Language switch rewrites to the primary slug (`CatalogIdentityBridge`) so the target locale can canonical-redirect — never keep a foreign-language handle. See `docs/adr/0004-translatable-slugs.md`.
 
 **Invalidation:** Product update → `revalidateTag("product:{slug}")` → busts EN/PL/DE cached entries → `revalidatePath` for every `/{locale}/{channel}/products/{slug}`.
 
@@ -128,7 +128,8 @@ Run **301** from old URLs for at least one release.
 ❌ **Hardcoding `EN_US` / `PL_PL` in `graphqlLanguageCode`** — Dashboard translations use base codes (`EN`, `PL`); see `src/config/locale.ts`  
 ❌ **Omitting `localeSlug` from cached fetches** — All locales would share one cache entry and wrong language  
 ❌ **Overwriting `entity.slug` with the translation** — Breaks cache tags / webhooks; use `pickTranslatedSlug` for URLs only  
-❌ **Assuming Saleor falls back between primary and translated slug lookups** — Client must try both (`resolveByPossiblyTranslatedSlug`)
+❌ **Assuming Saleor falls back between primary and translated slug lookups** — Client must try both (`resolveByPossiblyTranslatedSlug`)  
+❌ **Keeping a translated slug when switching locale** — Foreign-language handles 404; rewrite to primary slug via `CatalogIdentityBridge`
 
 ---
 

--- a/skills/saleor-paper-storefront/rules/ui-locale-routing.md
+++ b/skills/saleor-paper-storefront/rules/ui-locale-routing.md
@@ -82,6 +82,8 @@ Browse performance is unchanged after locale routing — locale is part of the *
 
 **GraphQL:** Map URL slugs to Saleor **base** language codes in `src/config/locale.ts` (`pl` → `PL`, not `PL_PL`). Merge `translation { … }` fields after fetch (`src/lib/saleor-translations.ts`).
 
+**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. See `docs/adr/0004-translatable-slugs.md`.
+
 **Invalidation:** Product update → `revalidateTag("product:{slug}")` → busts EN/PL/DE cached entries → `revalidatePath` for every `/{locale}/{channel}/products/{slug}`.
 
 Full detail: `data-caching.md` § Locale & Caching.
@@ -124,7 +126,9 @@ Run **301** from old URLs for at least one release.
 ❌ **Putting locale after channel** (`/uk/en/…`) — conflicts with this ADR  
 ❌ **Implementing `[locale]` routes** before ADR helpers and redirect plan exist  
 ❌ **Hardcoding `EN_US` / `PL_PL` in `graphqlLanguageCode`** — Dashboard translations use base codes (`EN`, `PL`); see `src/config/locale.ts`  
-❌ **Omitting `localeSlug` from cached fetches** — All locales would share one cache entry and wrong language
+❌ **Omitting `localeSlug` from cached fetches** — All locales would share one cache entry and wrong language  
+❌ **Overwriting `entity.slug` with the translation** — Breaks cache tags / webhooks; use `pickTranslatedSlug` for URLs only  
+❌ **Assuming Saleor falls back between primary and translated slug lookups** — Client must try both (`resolveByPossiblyTranslatedSlug`)
 
 ---
 

--- a/skills/saleor-paper-storefront/rules/ui-locale-routing.md
+++ b/skills/saleor-paper-storefront/rules/ui-locale-routing.md
@@ -82,7 +82,7 @@ Browse performance is unchanged after locale routing — locale is part of the *
 
 **GraphQL:** Map URL slugs to Saleor **base** language codes in `src/config/locale.ts` (`pl` → `PL`, not `PL_PL`). Merge `translation { … }` fields after fetch (`src/lib/saleor-translations.ts`).
 
-**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. Language switch rewrites to the primary slug (`CatalogIdentityBridge`) so the target locale can canonical-redirect — never keep a foreign-language handle. See `docs/adr/0004-translatable-slugs.md`.
+**Translatable catalog slugs (Saleor 3.21+):** Product / category / collection / page URLs may use `translation.slug` per locale. Resolve with `slugLanguageCode` then primary fallback for **every** locale (`src/lib/catalog/resolve-by-slug.ts`); build links with `pickTranslatedSlug`; keep `entity.slug` as cache/webhook identity. Fetch all locale handles via `*LocaleSlugTranslations` aliases (`buildLocaleSlugMap`) for hreflang and zero-hop language switching. See `docs/adr/0004-translatable-slugs.md`.
 
 **Invalidation:** Product update → `revalidateTag("product:{slug}")` → busts EN/PL/DE cached entries → `revalidatePath` for every `/{locale}/{channel}/products/{slug}`.
 

--- a/src/app/(storefront)/[locale]/[channel]/(main)/categories/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/categories/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { type Metadata } from "next";
 import { ProductListByCategoryDocument } from "@/gql/graphql";
 import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
+import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { getCategoryData } from "@/lib/catalog/get-category-data";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { parseEditorJSToText } from "@/lib/editorjs";
@@ -12,6 +13,7 @@ import { buildBrowsePageMetadata } from "@/lib/seo";
 import { CategoryHero, ProductsGridSkeleton, toProductCardData } from "@/ui/components/plp";
 import { buildSortVariables, buildFilterVariables } from "@/ui/components/plp/filter-utils";
 import { buildStorefrontPath } from "@/lib/storefront-path";
+import { pickTranslatedSlug } from "@/lib/saleor-translations";
 import { CategoryPageClient } from "./client";
 
 type PageProps = {
@@ -36,7 +38,9 @@ export const generateMetadata = async (props: PageProps): Promise<Metadata> => {
 		description: category?.seoDescription || plainDescription || category?.name,
 		locale: params.locale,
 		channel: params.channel,
-		pathSuffix: `/categories/${encodeURIComponent(params.slug)}`,
+		pathSuffix: category
+			? catalogPathSuffix("categories", category)
+			: `/categories/${encodeURIComponent(params.slug)}`,
 	});
 };
 
@@ -60,7 +64,19 @@ export default async function Page(props: PageProps) {
 		notFound();
 	}
 
+	if (decodeURIComponent(resolvedParams.slug) !== pickTranslatedSlug(category)) {
+		redirectToCanonicalCatalogSlug({
+			locale: resolvedParams.locale,
+			channel: resolvedParams.channel,
+			urlSlug: resolvedParams.slug,
+			kind: "categories",
+			entity: category,
+			searchParams: await props.searchParams,
+		});
+	}
+
 	const plainDescription = parseEditorJSToText(category.description);
+	const categoryPath = catalogPathSuffix("categories", category);
 
 	const breadcrumbs = [
 		{
@@ -69,11 +85,7 @@ export default async function Page(props: PageProps) {
 		},
 		{
 			label: category.name,
-			href: buildStorefrontPath(
-				resolvedParams.locale,
-				resolvedParams.channel,
-				`/categories/${resolvedParams.slug}`,
-			),
+			href: buildStorefrontPath(resolvedParams.locale, resolvedParams.channel, categoryPath),
 		},
 	];
 
@@ -108,9 +120,15 @@ async function CategoryProducts({
 	const sortBy = buildSortVariables(searchParams.sort);
 	const filter = buildFilterVariables({ priceRange: searchParams.price });
 
+	// Resolve via cached getCategoryData (handles translated URL slugs), then list by primary slug.
+	const category = await getCategoryData(params.slug, params.channel, params.locale);
+	if (!category) {
+		notFound();
+	}
+
 	const result = await executePublicGraphQL(ProductListByCategoryDocument, {
 		variables: {
-			slug: params.slug,
+			slug: category.slug,
 			channel: params.channel,
 			...paginationVariables,
 			sortBy,

--- a/src/app/(storefront)/[locale]/[channel]/(main)/categories/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/categories/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { ProductListByCategoryDocument } from "@/gql/graphql";
 import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
+import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getCategoryData } from "@/lib/catalog/get-category-data";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { parseEditorJSToText } from "@/lib/editorjs";
@@ -91,6 +92,7 @@ export default async function Page(props: PageProps) {
 
 	return (
 		<>
+			<CatalogIdentityBridge kind="categories" primarySlug={category.slug} />
 			{/* Static shell — cached hero renders immediately, prerendered into the PPR shell */}
 			<CategoryHero
 				title={category.name}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/categories/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/categories/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { executePublicGraphQL } from "@/lib/graphql";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getCategoryData } from "@/lib/catalog/get-category-data";
+import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "@/lib/catalog/locale-slugs";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { parseEditorJSToText } from "@/lib/editorjs";
 import { buildBrowsePageMetadata } from "@/lib/seo";
@@ -42,6 +43,9 @@ export const generateMetadata = async (props: PageProps): Promise<Metadata> => {
 		pathSuffix: category
 			? catalogPathSuffix("categories", category)
 			: `/categories/${encodeURIComponent(params.slug)}`,
+		pathSuffixByLocale: category
+			? buildCatalogPathSuffixByLocale("categories", buildLocaleSlugMap(category))
+			: undefined,
 	});
 };
 
@@ -92,7 +96,11 @@ export default async function Page(props: PageProps) {
 
 	return (
 		<>
-			<CatalogIdentityBridge kind="categories" primarySlug={category.slug} />
+			<CatalogIdentityBridge
+				kind="categories"
+				primarySlug={category.slug}
+				localeSlugs={buildLocaleSlugMap(category)}
+			/>
 			{/* Static shell — cached hero renders immediately, prerendered into the PPR shell */}
 			<CategoryHero
 				title={category.name}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/collections/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/collections/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { executePublicGraphQL } from "@/lib/graphql";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getCollectionData } from "@/lib/catalog/get-collection-data";
+import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "@/lib/catalog/locale-slugs";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { parseEditorJSToText } from "@/lib/editorjs";
 import { buildBrowsePageMetadata } from "@/lib/seo";
@@ -42,6 +43,9 @@ export const generateMetadata = async (props: PageProps): Promise<Metadata> => {
 		pathSuffix: collection
 			? catalogPathSuffix("collections", collection)
 			: `/collections/${encodeURIComponent(params.slug)}`,
+		pathSuffixByLocale: collection
+			? buildCatalogPathSuffixByLocale("collections", buildLocaleSlugMap(collection))
+			: undefined,
 	});
 };
 
@@ -85,7 +89,11 @@ export default async function Page(props: PageProps) {
 
 	return (
 		<>
-			<CatalogIdentityBridge kind="collections" primarySlug={collection.slug} />
+			<CatalogIdentityBridge
+				kind="collections"
+				primarySlug={collection.slug}
+				localeSlugs={buildLocaleSlugMap(collection)}
+			/>
 			<CategoryHero
 				title={collection.name}
 				description={plainDescription}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/collections/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/collections/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { type Metadata } from "next";
 import { ProductListByCollectionDocument, ProductOrderField, OrderDirection } from "@/gql/graphql";
 import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
+import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { getCollectionData } from "@/lib/catalog/get-collection-data";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { parseEditorJSToText } from "@/lib/editorjs";
@@ -12,6 +13,7 @@ import { buildBrowsePageMetadata } from "@/lib/seo";
 import { CategoryHero, ProductsGridSkeleton, toProductCardData } from "@/ui/components/plp";
 import { buildSortVariables, buildFilterVariables } from "@/ui/components/plp/filter-utils";
 import { buildStorefrontPath } from "@/lib/storefront-path";
+import { pickTranslatedSlug } from "@/lib/saleor-translations";
 import { CollectionPageClient } from "./client";
 
 type PageProps = {
@@ -36,7 +38,9 @@ export const generateMetadata = async (props: PageProps): Promise<Metadata> => {
 		description: collection?.seoDescription || plainDescription || collection?.name,
 		locale: params.locale,
 		channel: params.channel,
-		pathSuffix: `/collections/${encodeURIComponent(params.slug)}`,
+		pathSuffix: collection
+			? catalogPathSuffix("collections", collection)
+			: `/collections/${encodeURIComponent(params.slug)}`,
 	});
 };
 
@@ -56,13 +60,25 @@ export default async function Page(props: PageProps) {
 		notFound();
 	}
 
+	if (decodeURIComponent(params.slug) !== pickTranslatedSlug(collection)) {
+		redirectToCanonicalCatalogSlug({
+			locale: params.locale,
+			channel: params.channel,
+			urlSlug: params.slug,
+			kind: "collections",
+			entity: collection,
+			searchParams: await props.searchParams,
+		});
+	}
+
 	const plainDescription = parseEditorJSToText(collection.description);
+	const collectionPath = catalogPathSuffix("collections", collection);
 
 	const breadcrumbs = [
 		{ label: tListing("breadcrumbHome"), href: buildStorefrontPath(params.locale, params.channel) },
 		{
 			label: collection.name,
-			href: buildStorefrontPath(params.locale, params.channel, `/collections/${params.slug}`),
+			href: buildStorefrontPath(params.locale, params.channel, collectionPath),
 		},
 	];
 
@@ -98,9 +114,14 @@ async function CollectionProducts({
 	};
 	const filter = buildFilterVariables({ priceRange: searchParams.price });
 
+	const collection = await getCollectionData(params.slug, params.channel, params.locale);
+	if (!collection) {
+		notFound();
+	}
+
 	const result = await executePublicGraphQL(ProductListByCollectionDocument, {
 		variables: {
-			slug: params.slug,
+			slug: collection.slug,
 			channel: params.channel,
 			...paginationVariables,
 			sortBy,

--- a/src/app/(storefront)/[locale]/[channel]/(main)/collections/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/collections/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { ProductListByCollectionDocument, ProductOrderField, OrderDirection } fr
 import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
+import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getCollectionData } from "@/lib/catalog/get-collection-data";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { parseEditorJSToText } from "@/lib/editorjs";
@@ -84,6 +85,7 @@ export default async function Page(props: PageProps) {
 
 	return (
 		<>
+			<CatalogIdentityBridge kind="collections" primarySlug={collection.slug} />
 			<CategoryHero
 				title={collection.name}
 				description={plainDescription}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/page.tsx
@@ -5,6 +5,7 @@ import { resolveChannelCurrency } from "@/lib/channels/resolve-channel-currency"
 import { buildPolicyLabelValues } from "@/lib/content";
 import { formatContentLabel } from "@/lib/content/format-label";
 import { getStorefrontContent } from "@/lib/content/server";
+import { pickTranslatedSlug } from "@/lib/saleor-translations";
 import { PaperSignEditorialPlaceholder } from "@/ui/components/shared/paper-sign";
 import { CategoryTileGrid, type CategoryTile } from "@/ui/sections/category-tile-grid/category-tile-grid";
 import { EditorialHero } from "@/ui/sections/editorial-hero/editorial-hero";
@@ -45,7 +46,7 @@ function buildCategoryTiles(products: readonly FeaturedProduct[], max = 3): Cate
 		const imageAlt = category.backgroundImage?.alt || product.thumbnail?.alt || categoryName;
 		tiles.push({
 			title: categoryName,
-			href: `/categories/${category.slug}`,
+			href: `/categories/${pickTranslatedSlug(category)}`,
 			image,
 			imageAlt,
 		});

--- a/src/app/(storefront)/[locale]/[channel]/(main)/pages/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/pages/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { type Metadata } from "next";
 import edjsHTML from "editorjs-html";
 import xss from "xss";
+import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { getPageData } from "@/lib/catalog/get-page-data";
 import { buildBrowsePageMetadata } from "@/lib/seo";
 import { PageContentSkeleton } from "@/ui/components/page-content-skeleton";
@@ -20,14 +21,14 @@ export const generateMetadata = async (props: {
 		description: page?.seoDescription || page?.title,
 		locale: params.locale,
 		channel: params.channel,
-		pathSuffix: `/pages/${encodeURIComponent(params.slug)}`,
+		pathSuffix: page ? catalogPathSuffix("pages", page) : `/pages/${encodeURIComponent(params.slug)}`,
 	});
 };
 
 /**
  * Sync page shell — CMS content streams inside a Suspense island (Cache Components / PPR).
  */
-export default function Page(props: { params: Promise<{ slug: string; locale: string }> }) {
+export default function Page(props: { params: Promise<{ slug: string; locale: string; channel: string }> }) {
 	return (
 		<Suspense fallback={<PageContentSkeleton />}>
 			<PageContent params={props.params} />
@@ -35,13 +36,25 @@ export default function Page(props: { params: Promise<{ slug: string; locale: st
 	);
 }
 
-async function PageContent({ params: paramsPromise }: { params: Promise<{ slug: string; locale: string }> }) {
+async function PageContent({
+	params: paramsPromise,
+}: {
+	params: Promise<{ slug: string; locale: string; channel: string }>;
+}) {
 	const params = await paramsPromise;
 	const page = await getPageData(params.slug, params.locale);
 
 	if (!page) {
 		notFound();
 	}
+
+	redirectToCanonicalCatalogSlug({
+		locale: params.locale,
+		channel: params.channel,
+		urlSlug: params.slug,
+		kind: "pages",
+		entity: page,
+	});
 
 	const { title, content } = page;
 

--- a/src/app/(storefront)/[locale]/[channel]/(main)/pages/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/pages/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { type Metadata } from "next";
 import edjsHTML from "editorjs-html";
 import xss from "xss";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
+import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getPageData } from "@/lib/catalog/get-page-data";
 import { buildBrowsePageMetadata } from "@/lib/seo";
 import { PageContentSkeleton } from "@/ui/components/page-content-skeleton";
@@ -62,6 +63,7 @@ async function PageContent({
 
 	return (
 		<div className="container-content py-8 pb-16">
+			<CatalogIdentityBridge kind="pages" primarySlug={page.slug} />
 			<h1 className="mb-6 text-balance text-h1">{title}</h1>
 			{contentHtml && (
 				<div className="prose">

--- a/src/app/(storefront)/[locale]/[channel]/(main)/pages/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/pages/[slug]/page.tsx
@@ -6,6 +6,7 @@ import xss from "xss";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getPageData } from "@/lib/catalog/get-page-data";
+import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "@/lib/catalog/locale-slugs";
 import { buildBrowsePageMetadata } from "@/lib/seo";
 import { PageContentSkeleton } from "@/ui/components/page-content-skeleton";
 
@@ -23,6 +24,7 @@ export const generateMetadata = async (props: {
 		locale: params.locale,
 		channel: params.channel,
 		pathSuffix: page ? catalogPathSuffix("pages", page) : `/pages/${encodeURIComponent(params.slug)}`,
+		pathSuffixByLocale: page ? buildCatalogPathSuffixByLocale("pages", buildLocaleSlugMap(page)) : undefined,
 	});
 };
 
@@ -63,7 +65,7 @@ async function PageContent({
 
 	return (
 		<div className="container-content py-8 pb-16">
-			<CatalogIdentityBridge kind="pages" primarySlug={page.slug} />
+			<CatalogIdentityBridge kind="pages" primarySlug={page.slug} localeSlugs={buildLocaleSlugMap(page)} />
 			<h1 className="mb-6 text-balance text-h1">{title}</h1>
 			{contentHtml && (
 				<div className="prose">

--- a/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { resolveChannelCurrency } from "@/lib/channels/resolve-channel-currency"
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getProductData } from "@/lib/catalog/get-product-data";
+import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "@/lib/catalog/locale-slugs";
 import { buildPolicyLabelValues } from "@/lib/content";
 import { getStorefrontContent } from "@/lib/content/server";
 import { buildBrowsePageMetadata, buildProductJsonLd, jsonLdScriptProps } from "@/lib/seo";
@@ -60,6 +61,7 @@ export async function generateMetadata(props: {
 		locale: params.locale,
 		channel: params.channel,
 		pathSuffix: catalogPathSuffix("products", product),
+		pathSuffixByLocale: buildCatalogPathSuffixByLocale("products", buildLocaleSlugMap(product)),
 		openGraph:
 			priceAmount && priceCurrency
 				? {
@@ -200,7 +202,11 @@ async function ProductShell({
 
 	return (
 		<div className="flex min-h-screen flex-col bg-background">
-			<CatalogIdentityBridge kind="products" primarySlug={product.slug} />
+			<CatalogIdentityBridge
+				kind="products"
+				primarySlug={product.slug}
+				localeSlugs={buildLocaleSlugMap(product)}
+			/>
 			{productJsonLd && <script {...jsonLdScriptProps(productJsonLd)} />}
 
 			{/* The browse layout (`(main)/layout.tsx`) owns the page's single <main> landmark. */}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { type ProductDetailsQuery } from "@/gql/graphql";
 import { resolveLocaleFromSlug } from "@/config/locale";
 import { resolveChannelCurrency } from "@/lib/channels/resolve-channel-currency";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
+import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getProductData } from "@/lib/catalog/get-product-data";
 import { buildPolicyLabelValues } from "@/lib/content";
 import { getStorefrontContent } from "@/lib/content/server";
@@ -199,6 +200,7 @@ async function ProductShell({
 
 	return (
 		<div className="flex min-h-screen flex-col bg-background">
+			<CatalogIdentityBridge kind="products" primarySlug={product.slug} />
 			{productJsonLd && <script {...jsonLdScriptProps(productJsonLd)} />}
 
 			{/* The browse layout (`(main)/layout.tsx`) owns the page's single <main> landmark. */}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
@@ -6,17 +6,16 @@ import { ErrorBoundary } from "react-error-boundary";
 import edjsHTML from "editorjs-html";
 import xss from "xss";
 
-import { executePublicGraphQL } from "@/lib/graphql";
-import { ProductDetailsDocument, type ProductDetailsQuery } from "@/gql/graphql";
+import { type ProductDetailsQuery } from "@/gql/graphql";
 import { resolveLocaleFromSlug } from "@/config/locale";
 import { resolveChannelCurrency } from "@/lib/channels/resolve-channel-currency";
+import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
+import { getProductData } from "@/lib/catalog/get-product-data";
 import { buildPolicyLabelValues } from "@/lib/content";
 import { getStorefrontContent } from "@/lib/content/server";
 import { buildBrowsePageMetadata, buildProductJsonLd, jsonLdScriptProps } from "@/lib/seo";
-import { CACHE_PROFILES, applyCacheProfile } from "@/lib/cache-manifest";
-import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { buildStorefrontPath } from "@/lib/storefront-path";
-import { withTranslatedProductFields, pickTranslatedName } from "@/lib/saleor-translations";
+import { pickTranslatedName, pickTranslatedSlug } from "@/lib/saleor-translations";
 import { isBestseller, BESTSELLER_ATTRIBUTE_SLUGS } from "@/lib/catalog/product-flags";
 import { getAttributeValueDisplayName } from "@/ui/components/pdp/variant-selection/utils";
 import { Breadcrumbs } from "@/ui/components/breadcrumbs";
@@ -33,30 +32,6 @@ import {
 	PDP_GALLERY_LAYOUT,
 	PDP_LAYOUT_CLASSES,
 } from "@/ui/components/pdp";
-
-// ============================================================================
-// Cached Data Fetching
-// ============================================================================
-
-async function getProductData(slug: string, channel: string, localeSlug: string) {
-	"use cache";
-	applyCacheProfile(CACHE_PROFILES.products, slug);
-
-	const result = await executePublicGraphQL(ProductDetailsDocument, {
-		variables: {
-			slug: decodeURIComponent(slug),
-			channel,
-			...graphqlLanguageCodeVariables(localeSlug),
-		},
-	});
-
-	if (!result.ok) {
-		console.error(`[getProductData] Failed to fetch product ${slug} for ${channel}:`, result.error.message);
-		return null;
-	}
-
-	return result.data.product ? withTranslatedProductFields(result.data.product) : null;
-}
 
 // ============================================================================
 // Metadata
@@ -83,7 +58,7 @@ export async function generateMetadata(props: {
 		image: ogImage,
 		locale: params.locale,
 		channel: params.channel,
-		pathSuffix: `/products/${encodeURIComponent(params.slug)}`,
+		pathSuffix: catalogPathSuffix("products", product),
 		openGraph:
 			priceAmount && priceCurrency
 				? {
@@ -119,7 +94,8 @@ export default function ProductPage(props: {
 }
 
 /**
- * Static product shell — only reads route params (cacheable / prerenderable).
+ * Product shell — reads route params for the static/PPR path.
+ * Awaits searchParams only when issuing a canonical-slug redirect (rare).
  * Dynamic islands (gallery + variant section) read searchParams in nested Suspense.
  */
 async function ProductShell({
@@ -147,15 +123,34 @@ async function ProductShell({
 		notFound();
 	}
 
+	// Only await searchParams on the rare non-canonical slug path so the common
+	// (already-canonical) PDP shell stays params-only / PPR-static.
+	if (decodeURIComponent(params.slug) !== pickTranslatedSlug(product)) {
+		redirectToCanonicalCatalogSlug({
+			locale: params.locale,
+			channel: params.channel,
+			urlSlug: params.slug,
+			kind: "products",
+			entity: product,
+			searchParams: await searchParams,
+		});
+	}
+
 	const descriptionHtml = parseDescription(product.description);
 	const productAttributes = extractProductAttributes(product);
 	const careInstructions = extractCareInstructions(product);
 	const defaultImages = getDefaultGalleryImages(product);
+	const productPath = catalogPathSuffix("products", product);
 
 	const breadcrumbs = [
 		{ label: tPdp("breadcrumbHome"), href: browse("/") },
 		...(product.category
-			? [{ label: product.category.name, href: browse(`/categories/${product.category.slug}`) }]
+			? [
+					{
+						label: product.category.name,
+						href: browse(catalogPathSuffix("categories", product.category)),
+					},
+				]
 			: []),
 		{ label: product.name },
 	];
@@ -165,7 +160,7 @@ async function ProductShell({
 		description: product.seoDescription || product.name,
 		images: defaultImages.length > 0 ? defaultImages.map((img) => img.url) : undefined,
 		brand: product.category?.name,
-		url: browse(`/products/${product.slug}`),
+		url: browse(productPath),
 		priceRange: product.pricing?.priceRange?.start?.gross
 			? {
 					lowPrice: product.pricing.priceRange.start.gross.amount,

--- a/src/graphql/LocaleSlugTranslations.graphql
+++ b/src/graphql/LocaleSlugTranslations.graphql
@@ -1,0 +1,89 @@
+# Locale-canonical catalog URL slugs for every Paper-supported language.
+# Alias names are `slug` + Saleor LanguageCodeEnum (EN, PL, …) — keep in sync with
+# LOCALE_DEFINITIONS in src/config/locale.ts when adding languages.
+#
+# Used for hreflang alternates and zero-hop language switching (ADR 0004 phase 2).
+
+fragment ProductLocaleSlugTranslations on Product {
+	slugEN: translation(languageCode: EN) {
+		slug
+	}
+	slugPL: translation(languageCode: PL) {
+		slug
+	}
+	slugDE: translation(languageCode: DE) {
+		slug
+	}
+	slugFR: translation(languageCode: FR) {
+		slug
+	}
+	slugFI: translation(languageCode: FI) {
+		slug
+	}
+	slugNB: translation(languageCode: NB) {
+		slug
+	}
+}
+
+fragment CategoryLocaleSlugTranslations on Category {
+	slugEN: translation(languageCode: EN) {
+		slug
+	}
+	slugPL: translation(languageCode: PL) {
+		slug
+	}
+	slugDE: translation(languageCode: DE) {
+		slug
+	}
+	slugFR: translation(languageCode: FR) {
+		slug
+	}
+	slugFI: translation(languageCode: FI) {
+		slug
+	}
+	slugNB: translation(languageCode: NB) {
+		slug
+	}
+}
+
+fragment CollectionLocaleSlugTranslations on Collection {
+	slugEN: translation(languageCode: EN) {
+		slug
+	}
+	slugPL: translation(languageCode: PL) {
+		slug
+	}
+	slugDE: translation(languageCode: DE) {
+		slug
+	}
+	slugFR: translation(languageCode: FR) {
+		slug
+	}
+	slugFI: translation(languageCode: FI) {
+		slug
+	}
+	slugNB: translation(languageCode: NB) {
+		slug
+	}
+}
+
+fragment PageLocaleSlugTranslations on Page {
+	slugEN: translation(languageCode: EN) {
+		slug
+	}
+	slugPL: translation(languageCode: PL) {
+		slug
+	}
+	slugDE: translation(languageCode: DE) {
+		slug
+	}
+	slugFR: translation(languageCode: FR) {
+		slug
+	}
+	slugFI: translation(languageCode: FI) {
+		slug
+	}
+	slugNB: translation(languageCode: NB) {
+		slug
+	}
+}

--- a/src/graphql/MenuGetBySlug.graphql
+++ b/src/graphql/MenuGetBySlug.graphql
@@ -11,6 +11,7 @@ fragment MenuItem on MenuItem {
 		name
 		translation(languageCode: $languageCode) {
 			name
+			slug
 		}
 	}
 	collection {
@@ -19,6 +20,7 @@ fragment MenuItem on MenuItem {
 		slug
 		translation(languageCode: $languageCode) {
 			name
+			slug
 		}
 	}
 	page {
@@ -27,6 +29,7 @@ fragment MenuItem on MenuItem {
 		slug
 		translation(languageCode: $languageCode) {
 			title
+			slug
 		}
 	}
 	url

--- a/src/graphql/PageGetBySlug.graphql
+++ b/src/graphql/PageGetBySlug.graphql
@@ -13,5 +13,6 @@ query PageGetBySlug($slug: String!, $languageCode: LanguageCodeEnum!, $slugLangu
 			content
 			slug
 		}
+		...PageLocaleSlugTranslations
 	}
 }

--- a/src/graphql/PageGetBySlug.graphql
+++ b/src/graphql/PageGetBySlug.graphql
@@ -1,5 +1,5 @@
-query PageGetBySlug($slug: String!, $languageCode: LanguageCodeEnum!) {
-	page(slug: $slug) {
+query PageGetBySlug($slug: String!, $languageCode: LanguageCodeEnum!, $slugLanguageCode: LanguageCodeEnum) {
+	page(slug: $slug, slugLanguageCode: $slugLanguageCode) {
 		id
 		slug
 		title
@@ -11,6 +11,7 @@ query PageGetBySlug($slug: String!, $languageCode: LanguageCodeEnum!) {
 			seoTitle
 			seoDescription
 			content
+			slug
 		}
 	}
 }

--- a/src/graphql/ProductDetails.graphql
+++ b/src/graphql/ProductDetails.graphql
@@ -18,6 +18,7 @@ query ProductDetails(
 			seoDescription
 			slug
 		}
+		...ProductLocaleSlugTranslations
 		thumbnail(size: 2048, format: WEBP) {
 			url
 			alt

--- a/src/graphql/ProductDetails.graphql
+++ b/src/graphql/ProductDetails.graphql
@@ -1,5 +1,10 @@
-query ProductDetails($slug: String!, $channel: String!, $languageCode: LanguageCodeEnum!) {
-	product(slug: $slug, channel: $channel) {
+query ProductDetails(
+	$slug: String!
+	$channel: String!
+	$languageCode: LanguageCodeEnum!
+	$slugLanguageCode: LanguageCodeEnum
+) {
+	product(slug: $slug, channel: $channel, slugLanguageCode: $slugLanguageCode) {
 		id
 		name
 		slug
@@ -11,6 +16,7 @@ query ProductDetails($slug: String!, $channel: String!, $languageCode: LanguageC
 			description
 			seoTitle
 			seoDescription
+			slug
 		}
 		thumbnail(size: 2048, format: WEBP) {
 			url
@@ -27,6 +33,7 @@ query ProductDetails($slug: String!, $channel: String!, $languageCode: LanguageC
 			slug
 			translation(languageCode: $languageCode) {
 				name
+				slug
 			}
 		}
 		# Bestseller merchandising flag — fetch only the boolean by slug (new attribute API).

--- a/src/graphql/ProductListByCategory.graphql
+++ b/src/graphql/ProductListByCategory.graphql
@@ -22,6 +22,7 @@ query ProductListByCategory(
 			seoTitle
 			slug
 		}
+		...CategoryLocaleSlugTranslations
 		backgroundImage {
 			url
 			alt

--- a/src/graphql/ProductListByCategory.graphql
+++ b/src/graphql/ProductListByCategory.graphql
@@ -2,12 +2,13 @@ query ProductListByCategory(
 	$slug: String!
 	$channel: String!
 	$languageCode: LanguageCodeEnum!
+	$slugLanguageCode: LanguageCodeEnum
 	$first: Int
 	$after: String
 	$sortBy: ProductOrder
 	$filter: ProductFilterInput
 ) {
-	category(slug: $slug) {
+	category(slug: $slug, slugLanguageCode: $slugLanguageCode) {
 		id
 		name
 		slug
@@ -19,6 +20,7 @@ query ProductListByCategory(
 			description
 			seoDescription
 			seoTitle
+			slug
 		}
 		backgroundImage {
 			url

--- a/src/graphql/ProductListByCollection.graphql
+++ b/src/graphql/ProductListByCollection.graphql
@@ -2,12 +2,13 @@ query ProductListByCollection(
 	$slug: String!
 	$channel: String!
 	$languageCode: LanguageCodeEnum!
+	$slugLanguageCode: LanguageCodeEnum
 	$first: Int
 	$after: String
 	$sortBy: ProductOrder
 	$filter: ProductFilterInput
 ) {
-	collection(slug: $slug, channel: $channel) {
+	collection(slug: $slug, channel: $channel, slugLanguageCode: $slugLanguageCode) {
 		id
 		name
 		slug
@@ -19,6 +20,7 @@ query ProductListByCollection(
 			description
 			seoDescription
 			seoTitle
+			slug
 		}
 		backgroundImage {
 			url

--- a/src/graphql/ProductListByCollection.graphql
+++ b/src/graphql/ProductListByCollection.graphql
@@ -22,6 +22,7 @@ query ProductListByCollection(
 			seoTitle
 			slug
 		}
+		...CollectionLocaleSlugTranslations
 		backgroundImage {
 			url
 			alt

--- a/src/graphql/ProductListItem.graphql
+++ b/src/graphql/ProductListItem.graphql
@@ -5,6 +5,7 @@ fragment ProductListItem on Product {
 	created
 	translation(languageCode: $languageCode) {
 		name
+		slug
 	}
 	pricing {
 		priceRange {
@@ -42,6 +43,7 @@ fragment ProductListItem on Product {
 		slug
 		translation(languageCode: $languageCode) {
 			name
+			slug
 		}
 		backgroundImage {
 			url

--- a/src/hooks/use-storefront-region-navigation.ts
+++ b/src/hooks/use-storefront-region-navigation.ts
@@ -4,7 +4,11 @@ import { useParams, usePathname, useRouter, useSearchParams } from "next/navigat
 import { isLocaleSlug, isStorefrontLocaleSlug } from "@/config/locale";
 import { getPairedChannelForLocale } from "@/config/locale-channel";
 import { useCatalogIdentity } from "@/lib/catalog/catalog-identity-bridge";
-import { appendSearchParams, rewriteCatalogSuffixForLocaleSwitch } from "@/lib/catalog/catalog-identity";
+import {
+	appendSearchParams,
+	rewriteCatalogSuffixForLocaleSwitch,
+	safeLocaleSwitchSuffixWithoutIdentity,
+} from "@/lib/catalog/catalog-identity";
 import { hasCartCookieForChannel } from "@/lib/cart-channel-cookie";
 import { writeBrowseLocaleCookieClient } from "@/lib/browse-locale";
 import {
@@ -16,7 +20,9 @@ import {
 /**
  * Navigate browse URLs while preserving the path suffix (ADR 0001).
  * On catalog detail pages, swap to the target locale's canonical slug when known
- * (ADR 0004 phase 2), else the primary slug (server 308s).
+ * (ADR 0004 phase 2), else the primary slug (server 308s). If identity is not
+ * registered yet (chrome streamed before the detail shell), drop the foreign
+ * handle instead of 404ing.
  */
 export function useStorefrontRegionNavigation() {
 	const router = useRouter();
@@ -47,15 +53,19 @@ export function useStorefrontRegionNavigation() {
 
 		const parsed = parseStorefrontPathname(pathname);
 		let suffix = parsed?.suffix ?? "";
-		if (catalogIdentity && parsed) {
-			suffix = rewriteCatalogSuffixForLocaleSwitch(suffix, catalogIdentity, newLocale);
+		if (parsed) {
+			suffix = catalogIdentity
+				? rewriteCatalogSuffixForLocaleSwitch(suffix, catalogIdentity, newLocale)
+				: safeLocaleSwitchSuffixWithoutIdentity(suffix);
 		}
 
 		const path = parsed
 			? buildStorefrontPath(newLocale, targetChannel, suffix)
 			: buildStorefrontPath(newLocale, targetChannel);
 
-		router.push(appendSearchParams(path, searchParams));
+		// Drop query when we abandoned a detail URL (listing/home has no variant/filters meaning).
+		const keepQuery = Boolean(catalogIdentity) || suffix === (parsed?.suffix ?? "");
+		router.push(appendSearchParams(path, keepQuery ? searchParams : undefined));
 	}
 
 	function navigateToChannel(newChannel: string) {

--- a/src/hooks/use-storefront-region-navigation.ts
+++ b/src/hooks/use-storefront-region-navigation.ts
@@ -4,7 +4,7 @@ import { useParams, usePathname, useRouter, useSearchParams } from "next/navigat
 import { isLocaleSlug, isStorefrontLocaleSlug } from "@/config/locale";
 import { getPairedChannelForLocale } from "@/config/locale-channel";
 import { useCatalogIdentity } from "@/lib/catalog/catalog-identity-bridge";
-import { appendSearchParams, rewriteCatalogSuffixWithPrimarySlug } from "@/lib/catalog/catalog-identity";
+import { appendSearchParams, rewriteCatalogSuffixForLocaleSwitch } from "@/lib/catalog/catalog-identity";
 import { hasCartCookieForChannel } from "@/lib/cart-channel-cookie";
 import { writeBrowseLocaleCookieClient } from "@/lib/browse-locale";
 import {
@@ -14,9 +14,9 @@ import {
 } from "@/lib/storefront-path";
 
 /**
- * Navigate browse URLs while preserving the path suffix (ADR 0001), except on
- * catalog detail pages with translated slugs: swap to the primary slug so the
- * target locale can resolve + canonical-redirect (ADR 0004).
+ * Navigate browse URLs while preserving the path suffix (ADR 0001).
+ * On catalog detail pages, swap to the target locale's canonical slug when known
+ * (ADR 0004 phase 2), else the primary slug (server 308s).
  */
 export function useStorefrontRegionNavigation() {
 	const router = useRouter();
@@ -48,7 +48,7 @@ export function useStorefrontRegionNavigation() {
 		const parsed = parseStorefrontPathname(pathname);
 		let suffix = parsed?.suffix ?? "";
 		if (catalogIdentity && parsed) {
-			suffix = rewriteCatalogSuffixWithPrimarySlug(suffix, catalogIdentity);
+			suffix = rewriteCatalogSuffixForLocaleSwitch(suffix, catalogIdentity, newLocale);
 		}
 
 		const path = parsed

--- a/src/hooks/use-storefront-region-navigation.ts
+++ b/src/hooks/use-storefront-region-navigation.ts
@@ -1,8 +1,10 @@
 "use client";
 
-import { useParams, usePathname, useRouter } from "next/navigation";
+import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { isLocaleSlug, isStorefrontLocaleSlug } from "@/config/locale";
 import { getPairedChannelForLocale } from "@/config/locale-channel";
+import { useCatalogIdentity } from "@/lib/catalog/catalog-identity-bridge";
+import { appendSearchParams, rewriteCatalogSuffixWithPrimarySlug } from "@/lib/catalog/catalog-identity";
 import { hasCartCookieForChannel } from "@/lib/cart-channel-cookie";
 import { writeBrowseLocaleCookieClient } from "@/lib/browse-locale";
 import {
@@ -11,11 +13,17 @@ import {
 	replaceStorefrontChannel,
 } from "@/lib/storefront-path";
 
-/** Navigate browse URLs while preserving the path suffix (ADR 0001 picker behavior). */
+/**
+ * Navigate browse URLs while preserving the path suffix (ADR 0001), except on
+ * catalog detail pages with translated slugs: swap to the primary slug so the
+ * target locale can resolve + canonical-redirect (ADR 0004).
+ */
 export function useStorefrontRegionNavigation() {
 	const router = useRouter();
 	const pathname = usePathname();
+	const searchParams = useSearchParams();
 	const params = useParams<{ locale?: string; channel?: string }>();
+	const catalogIdentity = useCatalogIdentity();
 
 	const locale = params.locale ?? "";
 	const channel = params.channel ?? "";
@@ -38,10 +46,16 @@ export function useStorefrontRegionNavigation() {
 		}
 
 		const parsed = parseStorefrontPathname(pathname);
-		const href = parsed
-			? buildStorefrontPath(newLocale, targetChannel, parsed.suffix)
+		let suffix = parsed?.suffix ?? "";
+		if (catalogIdentity && parsed) {
+			suffix = rewriteCatalogSuffixWithPrimarySlug(suffix, catalogIdentity);
+		}
+
+		const path = parsed
+			? buildStorefrontPath(newLocale, targetChannel, suffix)
 			: buildStorefrontPath(newLocale, targetChannel);
-		router.push(href);
+
+		router.push(appendSearchParams(path, searchParams));
 	}
 
 	function navigateToChannel(newChannel: string) {
@@ -57,8 +71,8 @@ export function useStorefrontRegionNavigation() {
 			if (!proceed) return;
 		}
 
-		const href = replaceStorefrontChannel(pathname, newChannel) ?? buildStorefrontPath(locale, newChannel);
-		router.push(href);
+		const path = replaceStorefrontChannel(pathname, newChannel) ?? buildStorefrontPath(locale, newChannel);
+		router.push(appendSearchParams(path, searchParams));
 	}
 
 	return { locale, channel, navigateToLocale, navigateToChannel };

--- a/src/lib/catalog/canonical-slug.test.ts
+++ b/src/lib/catalog/canonical-slug.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { permanentRedirect } from "next/navigation";
+import { redirectToCanonicalCatalogSlug } from "./canonical-slug";
+
+vi.mock("next/navigation", () => ({
+	permanentRedirect: vi.fn(),
+}));
+
+describe("redirectToCanonicalCatalogSlug", () => {
+	it("no-ops when the URL slug is already canonical", () => {
+		redirectToCanonicalCatalogSlug({
+			locale: "pl",
+			channel: "pl",
+			urlSlug: "bluza",
+			kind: "products",
+			entity: { slug: "hoodie", translation: { slug: "bluza" } },
+		});
+
+		expect(permanentRedirect).not.toHaveBeenCalled();
+	});
+
+	it("preserves search params on redirect", () => {
+		redirectToCanonicalCatalogSlug({
+			locale: "pl",
+			channel: "pl",
+			urlSlug: "hoodie",
+			kind: "products",
+			entity: { slug: "hoodie", translation: { slug: "bluza" } },
+			searchParams: { variant: "abc", sort: "price" },
+		});
+
+		expect(permanentRedirect).toHaveBeenCalledWith("/pl/pl/products/bluza?variant=abc&sort=price");
+	});
+});

--- a/src/lib/catalog/canonical-slug.ts
+++ b/src/lib/catalog/canonical-slug.ts
@@ -1,8 +1,9 @@
 import { permanentRedirect } from "next/navigation";
+import type { CatalogSlugKind } from "@/lib/catalog/catalog-identity";
 import { pickTranslatedSlug } from "@/lib/saleor-translations";
 import { buildStorefrontPath } from "@/lib/storefront-path";
 
-export type CatalogSlugKind = "products" | "categories" | "collections" | "pages";
+export type { CatalogSlugKind };
 
 type SluggedEntity = {
 	slug: string;

--- a/src/lib/catalog/canonical-slug.ts
+++ b/src/lib/catalog/canonical-slug.ts
@@ -1,0 +1,60 @@
+import { permanentRedirect } from "next/navigation";
+import { pickTranslatedSlug } from "@/lib/saleor-translations";
+import { buildStorefrontPath } from "@/lib/storefront-path";
+
+export type CatalogSlugKind = "products" | "categories" | "collections" | "pages";
+
+type SluggedEntity = {
+	slug: string;
+	translation?: { slug?: string | null } | null;
+};
+
+/** Path suffix using the locale-canonical catalog slug (`translation.slug ?? slug`). */
+export function catalogPathSuffix(kind: CatalogSlugKind, entity: SluggedEntity): string {
+	return `/${kind}/${encodeURIComponent(pickTranslatedSlug(entity))}`;
+}
+
+function toQueryString(searchParams: Record<string, string | string[] | undefined> | undefined): string {
+	if (!searchParams) return "";
+
+	const params = new URLSearchParams();
+	for (const [key, value] of Object.entries(searchParams)) {
+		if (value == null) continue;
+		if (Array.isArray(value)) {
+			for (const entry of value) {
+				if (entry != null && entry !== "") params.append(key, entry);
+			}
+			continue;
+		}
+		if (value !== "") params.set(key, value);
+	}
+
+	const query = params.toString();
+	return query ? `?${query}` : "";
+}
+
+/**
+ * 308 to the locale-canonical slug when the URL still uses the primary (or stale) slug.
+ * No-op when already canonical or when no translated slug is configured.
+ *
+ * Pass `searchParams` so deep links (`?variant=`, PLP filters) survive the redirect.
+ */
+export function redirectToCanonicalCatalogSlug(options: {
+	locale: string;
+	channel: string;
+	urlSlug: string;
+	kind: CatalogSlugKind;
+	entity: SluggedEntity;
+	searchParams?: Record<string, string | string[] | undefined>;
+}): void {
+	const canonical = pickTranslatedSlug(options.entity);
+	if (decodeURIComponent(options.urlSlug) === canonical) return;
+
+	const path = buildStorefrontPath(
+		options.locale,
+		options.channel,
+		`/${options.kind}/${encodeURIComponent(canonical)}`,
+	);
+
+	permanentRedirect(`${path}${toQueryString(options.searchParams)}`);
+}

--- a/src/lib/catalog/catalog-identity-bridge.tsx
+++ b/src/lib/catalog/catalog-identity-bridge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { createContext, useContext, useLayoutEffect, useMemo, useState, type ReactNode } from "react";
 import type { CatalogIdentity } from "@/lib/catalog/catalog-identity";
 
 type CatalogIdentityContextValue = {
@@ -27,13 +27,13 @@ export function useCatalogIdentity(): CatalogIdentity | null {
 
 /**
  * Registers the current catalog detail page for locale switching (primary + per-locale slugs).
- * Render once in product/category/collection/page shells.
+ * Uses layout effect so identity is available before paint (footer picker can run in parallel).
  */
 export function CatalogIdentityBridge({ kind, primarySlug, localeSlugs }: CatalogIdentity) {
 	const setIdentity = useContext(CatalogIdentityContext)?.setIdentity;
 	const localeSlugsKey = localeSlugs ? JSON.stringify(localeSlugs) : "";
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (!setIdentity) return;
 		setIdentity({
 			kind,

--- a/src/lib/catalog/catalog-identity-bridge.tsx
+++ b/src/lib/catalog/catalog-identity-bridge.tsx
@@ -26,17 +26,22 @@ export function useCatalogIdentity(): CatalogIdentity | null {
 }
 
 /**
- * Registers the current catalog detail page's primary slug for locale switching.
+ * Registers the current catalog detail page for locale switching (primary + per-locale slugs).
  * Render once in product/category/collection/page shells.
  */
-export function CatalogIdentityBridge({ kind, primarySlug }: CatalogIdentity) {
+export function CatalogIdentityBridge({ kind, primarySlug, localeSlugs }: CatalogIdentity) {
 	const setIdentity = useContext(CatalogIdentityContext)?.setIdentity;
+	const localeSlugsKey = localeSlugs ? JSON.stringify(localeSlugs) : "";
 
 	useEffect(() => {
 		if (!setIdentity) return;
-		setIdentity({ kind, primarySlug });
+		setIdentity({
+			kind,
+			primarySlug,
+			localeSlugs: localeSlugsKey ? (JSON.parse(localeSlugsKey) as Record<string, string>) : undefined,
+		});
 		return () => setIdentity(null);
-	}, [setIdentity, kind, primarySlug]);
+	}, [setIdentity, kind, primarySlug, localeSlugsKey]);
 
 	return null;
 }

--- a/src/lib/catalog/catalog-identity-bridge.tsx
+++ b/src/lib/catalog/catalog-identity-bridge.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { CatalogIdentity } from "@/lib/catalog/catalog-identity";
+
+type CatalogIdentityContextValue = {
+	identity: CatalogIdentity | null;
+	setIdentity: (identity: CatalogIdentity | null) => void;
+};
+
+const CatalogIdentityContext = createContext<CatalogIdentityContextValue | null>(null);
+
+/**
+ * Lives in browse chrome (`StorefrontProviders`) so the footer/header region picker
+ * can read the active catalog entity — page content registers via {@link CatalogIdentityBridge}.
+ */
+export function CatalogIdentityProvider({ children }: { children: ReactNode }) {
+	const [identity, setIdentity] = useState<CatalogIdentity | null>(null);
+	const value = useMemo(() => ({ identity, setIdentity }), [identity]);
+
+	return <CatalogIdentityContext.Provider value={value}>{children}</CatalogIdentityContext.Provider>;
+}
+
+export function useCatalogIdentity(): CatalogIdentity | null {
+	return useContext(CatalogIdentityContext)?.identity ?? null;
+}
+
+/**
+ * Registers the current catalog detail page's primary slug for locale switching.
+ * Render once in product/category/collection/page shells.
+ */
+export function CatalogIdentityBridge({ kind, primarySlug }: CatalogIdentity) {
+	const setIdentity = useContext(CatalogIdentityContext)?.setIdentity;
+
+	useEffect(() => {
+		if (!setIdentity) return;
+		setIdentity({ kind, primarySlug });
+		return () => setIdentity(null);
+	}, [setIdentity, kind, primarySlug]);
+
+	return null;
+}

--- a/src/lib/catalog/catalog-identity.test.ts
+++ b/src/lib/catalog/catalog-identity.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { appendSearchParams, rewriteCatalogSuffixForLocaleSwitch } from "./catalog-identity";
+import {
+	appendSearchParams,
+	rewriteCatalogSuffixForLocaleSwitch,
+	safeLocaleSwitchSuffixWithoutIdentity,
+} from "./catalog-identity";
 
 describe("rewriteCatalogSuffixForLocaleSwitch", () => {
 	it("uses the target locale slug when localeSlugs is provided", () => {
@@ -34,6 +38,23 @@ describe("rewriteCatalogSuffixForLocaleSwitch", () => {
 				"en",
 			),
 		).toBe("/categories/bluza");
+	});
+});
+
+describe("safeLocaleSwitchSuffixWithoutIdentity", () => {
+	it("drops PDP to the products listing", () => {
+		expect(safeLocaleSwitchSuffixWithoutIdentity("/products/bluza")).toBe("/products");
+	});
+
+	it("drops category/collection/page detail to home", () => {
+		expect(safeLocaleSwitchSuffixWithoutIdentity("/categories/odziez")).toBe("");
+		expect(safeLocaleSwitchSuffixWithoutIdentity("/collections/lato")).toBe("");
+		expect(safeLocaleSwitchSuffixWithoutIdentity("/pages/o-nas")).toBe("");
+	});
+
+	it("preserves non-detail suffixes", () => {
+		expect(safeLocaleSwitchSuffixWithoutIdentity("/products")).toBe("/products");
+		expect(safeLocaleSwitchSuffixWithoutIdentity("/cart")).toBe("/cart");
 	});
 });
 

--- a/src/lib/catalog/catalog-identity.test.ts
+++ b/src/lib/catalog/catalog-identity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { appendSearchParams, rewriteCatalogSuffixWithPrimarySlug } from "./catalog-identity";
+
+describe("rewriteCatalogSuffixWithPrimarySlug", () => {
+	it("replaces a translated product slug with the primary slug", () => {
+		expect(
+			rewriteCatalogSuffixWithPrimarySlug("/products/bluza", {
+				kind: "products",
+				primarySlug: "hoodie",
+			}),
+		).toBe("/products/hoodie");
+	});
+
+	it("leaves non-matching kinds unchanged", () => {
+		expect(
+			rewriteCatalogSuffixWithPrimarySlug("/categories/bluza", {
+				kind: "products",
+				primarySlug: "hoodie",
+			}),
+		).toBe("/categories/bluza");
+	});
+
+	it("leaves list paths unchanged", () => {
+		expect(
+			rewriteCatalogSuffixWithPrimarySlug("/products", {
+				kind: "products",
+				primarySlug: "hoodie",
+			}),
+		).toBe("/products");
+	});
+});
+
+describe("appendSearchParams", () => {
+	it("appends a query string", () => {
+		expect(appendSearchParams("/en/pl/products/hoodie", "variant=abc")).toBe(
+			"/en/pl/products/hoodie?variant=abc",
+		);
+	});
+
+	it("no-ops when empty", () => {
+		expect(appendSearchParams("/en/pl/products/hoodie", "")).toBe("/en/pl/products/hoodie");
+	});
+});

--- a/src/lib/catalog/catalog-identity.test.ts
+++ b/src/lib/catalog/catalog-identity.test.ts
@@ -1,32 +1,39 @@
 import { describe, expect, it } from "vitest";
-import { appendSearchParams, rewriteCatalogSuffixWithPrimarySlug } from "./catalog-identity";
+import { appendSearchParams, rewriteCatalogSuffixForLocaleSwitch } from "./catalog-identity";
 
-describe("rewriteCatalogSuffixWithPrimarySlug", () => {
-	it("replaces a translated product slug with the primary slug", () => {
+describe("rewriteCatalogSuffixForLocaleSwitch", () => {
+	it("uses the target locale slug when localeSlugs is provided", () => {
 		expect(
-			rewriteCatalogSuffixWithPrimarySlug("/products/bluza", {
-				kind: "products",
-				primarySlug: "hoodie",
-			}),
+			rewriteCatalogSuffixForLocaleSwitch(
+				"/products/bluza",
+				{
+					kind: "products",
+					primarySlug: "hoodie",
+					localeSlugs: { en: "hoodie", pl: "bluza", de: "kapuzenpullover" },
+				},
+				"de",
+			),
+		).toBe("/products/kapuzenpullover");
+	});
+
+	it("falls back to primary slug when the target locale is missing", () => {
+		expect(
+			rewriteCatalogSuffixForLocaleSwitch(
+				"/products/bluza",
+				{ kind: "products", primarySlug: "hoodie" },
+				"en",
+			),
 		).toBe("/products/hoodie");
 	});
 
 	it("leaves non-matching kinds unchanged", () => {
 		expect(
-			rewriteCatalogSuffixWithPrimarySlug("/categories/bluza", {
-				kind: "products",
-				primarySlug: "hoodie",
-			}),
+			rewriteCatalogSuffixForLocaleSwitch(
+				"/categories/bluza",
+				{ kind: "products", primarySlug: "hoodie" },
+				"en",
+			),
 		).toBe("/categories/bluza");
-	});
-
-	it("leaves list paths unchanged", () => {
-		expect(
-			rewriteCatalogSuffixWithPrimarySlug("/products", {
-				kind: "products",
-				primarySlug: "hoodie",
-			}),
-		).toBe("/products");
 	});
 });
 

--- a/src/lib/catalog/catalog-identity.ts
+++ b/src/lib/catalog/catalog-identity.ts
@@ -9,15 +9,24 @@ export type CatalogIdentity = {
 	kind: CatalogSlugKind;
 	/** Saleor primary slug — stable across locales (cache / webhook identity). */
 	primarySlug: string;
+	/**
+	 * Optional map of locale → canonical URL slug for zero-hop language switches.
+	 * When missing, falls back to primarySlug (server 308s to the locale canonical).
+	 */
+	localeSlugs?: Record<string, string>;
 };
 
 const CATALOG_DETAIL_SUFFIX = /^\/(products|categories|collections|pages)\/([^/]+)(\/.*)?$/;
 
 /**
- * When switching language, rewrite a translated URL slug to the primary slug so the
- * target locale can resolve + 308 to its own canonical slug (never 404).
+ * Rewrite a catalog detail suffix for a language switch.
+ * Prefers the target locale's translated slug when {@link CatalogIdentity.localeSlugs} is set.
  */
-export function rewriteCatalogSuffixWithPrimarySlug(suffix: string, identity: CatalogIdentity): string {
+export function rewriteCatalogSuffixForLocaleSwitch(
+	suffix: string,
+	identity: CatalogIdentity,
+	targetLocale: string,
+): string {
 	const match = suffix.match(CATALOG_DETAIL_SUFFIX);
 	if (!match) return suffix;
 
@@ -25,7 +34,13 @@ export function rewriteCatalogSuffixWithPrimarySlug(suffix: string, identity: Ca
 	const rest = match[3] ?? "";
 	if (kind !== identity.kind) return suffix;
 
-	return `/${kind}/${encodeURIComponent(identity.primarySlug)}${rest}`;
+	const slug = identity.localeSlugs?.[targetLocale] ?? identity.primarySlug;
+	return `/${kind}/${encodeURIComponent(slug)}${rest}`;
+}
+
+/** @deprecated Prefer {@link rewriteCatalogSuffixForLocaleSwitch} */
+export function rewriteCatalogSuffixWithPrimarySlug(suffix: string, identity: CatalogIdentity): string {
+	return rewriteCatalogSuffixForLocaleSwitch(suffix, identity, "");
 }
 
 export function appendSearchParams(

--- a/src/lib/catalog/catalog-identity.ts
+++ b/src/lib/catalog/catalog-identity.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for locale/channel switches on translated catalog URLs.
+ * Primary Saleor slug is identity; translated slugs are locale-canonical SEO skins.
+ */
+
+export type CatalogSlugKind = "products" | "categories" | "collections" | "pages";
+
+export type CatalogIdentity = {
+	kind: CatalogSlugKind;
+	/** Saleor primary slug — stable across locales (cache / webhook identity). */
+	primarySlug: string;
+};
+
+const CATALOG_DETAIL_SUFFIX = /^\/(products|categories|collections|pages)\/([^/]+)(\/.*)?$/;
+
+/**
+ * When switching language, rewrite a translated URL slug to the primary slug so the
+ * target locale can resolve + 308 to its own canonical slug (never 404).
+ */
+export function rewriteCatalogSuffixWithPrimarySlug(suffix: string, identity: CatalogIdentity): string {
+	const match = suffix.match(CATALOG_DETAIL_SUFFIX);
+	if (!match) return suffix;
+
+	const kind = match[1] as CatalogSlugKind;
+	const rest = match[3] ?? "";
+	if (kind !== identity.kind) return suffix;
+
+	return `/${kind}/${encodeURIComponent(identity.primarySlug)}${rest}`;
+}
+
+export function appendSearchParams(
+	path: string,
+	searchParams: { toString(): string } | string | undefined,
+): string {
+	if (!searchParams) return path;
+	const query = typeof searchParams === "string" ? searchParams : searchParams.toString();
+	if (!query) return path;
+	return `${path}?${query}`;
+}

--- a/src/lib/catalog/catalog-identity.ts
+++ b/src/lib/catalog/catalog-identity.ts
@@ -38,6 +38,21 @@ export function rewriteCatalogSuffixForLocaleSwitch(
 	return `/${kind}/${encodeURIComponent(slug)}${rest}`;
 }
 
+/**
+ * When catalog identity is not registered yet (footer ready, detail shell still streaming),
+ * do not keep a foreign-language handle — that 404s on Saleor. Drop to a safe suffix:
+ * products listing when on a PDP; otherwise browse home.
+ */
+export function safeLocaleSwitchSuffixWithoutIdentity(suffix: string): string {
+	const match = suffix.match(CATALOG_DETAIL_SUFFIX);
+	if (!match) return suffix;
+
+	const kind = match[1] as CatalogSlugKind;
+	// Only `/products` has an index route under (main)/.
+	if (kind === "products") return "/products";
+	return "";
+}
+
 /** @deprecated Prefer {@link rewriteCatalogSuffixForLocaleSwitch} */
 export function rewriteCatalogSuffixWithPrimarySlug(suffix: string, identity: CatalogIdentity): string {
 	return rewriteCatalogSuffixForLocaleSwitch(suffix, identity, "");

--- a/src/lib/catalog/get-category-data.ts
+++ b/src/lib/catalog/get-category-data.ts
@@ -1,22 +1,46 @@
-import { ProductListByCategoryDocument } from "@/gql/graphql";
+import { ProductListByCategoryDocument, type LanguageCodeEnum } from "@/gql/graphql";
 import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
 import { withTranslatedCategoryFields } from "@/lib/saleor-translations";
 import { CACHE_PROFILES, applyCacheProfile } from "@/lib/cache-manifest";
+import { resolveByPossiblyTranslatedSlug } from "@/lib/catalog/resolve-by-slug";
+import { tagPrimaryCatalogSlug } from "@/lib/catalog/tag-primary-slug";
 
 export async function getCategoryData(slug: string, channel: string, localeSlug: string) {
 	"use cache";
-	applyCacheProfile(CACHE_PROFILES.categories, slug);
+	const decodedSlug = decodeURIComponent(slug);
+	applyCacheProfile(CACHE_PROFILES.categories, decodedSlug);
 
-	const result = await executePublicGraphQL(ProductListByCategoryDocument, {
-		variables: { slug, channel, first: 1, ...graphqlLanguageCodeVariables(localeSlug) },
+	const languageVariables = graphqlLanguageCodeVariables(localeSlug);
+
+	const fetchCategory = async (vars: { slug: string; slugLanguageCode?: LanguageCodeEnum }) => {
+		const result = await executePublicGraphQL(ProductListByCategoryDocument, {
+			variables: {
+				slug: vars.slug,
+				channel,
+				first: 1,
+				...languageVariables,
+				...(vars.slugLanguageCode ? { slugLanguageCode: vars.slugLanguageCode } : {}),
+			},
+		});
+
+		if (!result.ok) {
+			console.error(`[getCategoryData] Failed to fetch category ${vars.slug}:`, result.error.message);
+			return null;
+		}
+
+		return result.data.category;
+	};
+
+	const category = await resolveByPossiblyTranslatedSlug({
+		localeSlug,
+		urlSlug: decodedSlug,
+		fetchByPrimarySlug: (urlSlug) => fetchCategory({ slug: urlSlug }),
+		fetchByTranslatedSlug: (urlSlug, slugLanguageCode) => fetchCategory({ slug: urlSlug, slugLanguageCode }),
 	});
 
-	if (!result.ok) {
-		console.error(`[getCategoryData] Failed to fetch category ${slug}:`, result.error.message);
-		return null;
-	}
+	if (!category) return null;
 
-	const category = result.data.category;
-	return category ? withTranslatedCategoryFields(category) : null;
+	tagPrimaryCatalogSlug(CACHE_PROFILES.categories, decodedSlug, category.slug);
+	return withTranslatedCategoryFields(category);
 }

--- a/src/lib/catalog/get-collection-data.ts
+++ b/src/lib/catalog/get-collection-data.ts
@@ -1,22 +1,47 @@
-import { ProductListByCollectionDocument } from "@/gql/graphql";
+import { ProductListByCollectionDocument, type LanguageCodeEnum } from "@/gql/graphql";
 import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
 import { withTranslatedCategoryFields } from "@/lib/saleor-translations";
 import { CACHE_PROFILES, applyCacheProfile } from "@/lib/cache-manifest";
+import { resolveByPossiblyTranslatedSlug } from "@/lib/catalog/resolve-by-slug";
+import { tagPrimaryCatalogSlug } from "@/lib/catalog/tag-primary-slug";
 
 export async function getCollectionData(slug: string, channel: string, localeSlug: string) {
 	"use cache";
-	applyCacheProfile(CACHE_PROFILES.collections, slug);
+	const decodedSlug = decodeURIComponent(slug);
+	applyCacheProfile(CACHE_PROFILES.collections, decodedSlug);
 
-	const result = await executePublicGraphQL(ProductListByCollectionDocument, {
-		variables: { slug, channel, first: 1, ...graphqlLanguageCodeVariables(localeSlug) },
+	const languageVariables = graphqlLanguageCodeVariables(localeSlug);
+
+	const fetchCollection = async (vars: { slug: string; slugLanguageCode?: LanguageCodeEnum }) => {
+		const result = await executePublicGraphQL(ProductListByCollectionDocument, {
+			variables: {
+				slug: vars.slug,
+				channel,
+				first: 1,
+				...languageVariables,
+				...(vars.slugLanguageCode ? { slugLanguageCode: vars.slugLanguageCode } : {}),
+			},
+		});
+
+		if (!result.ok) {
+			console.error(`[getCollectionData] Failed to fetch collection ${vars.slug}:`, result.error.message);
+			return null;
+		}
+
+		return result.data.collection;
+	};
+
+	const collection = await resolveByPossiblyTranslatedSlug({
+		localeSlug,
+		urlSlug: decodedSlug,
+		fetchByPrimarySlug: (urlSlug) => fetchCollection({ slug: urlSlug }),
+		fetchByTranslatedSlug: (urlSlug, slugLanguageCode) =>
+			fetchCollection({ slug: urlSlug, slugLanguageCode }),
 	});
 
-	if (!result.ok) {
-		console.error(`[getCollectionData] Failed to fetch collection ${slug}:`, result.error.message);
-		return null;
-	}
+	if (!collection) return null;
 
-	const collection = result.data.collection;
-	return collection ? withTranslatedCategoryFields(collection) : null;
+	tagPrimaryCatalogSlug(CACHE_PROFILES.collections, decodedSlug, collection.slug);
+	return withTranslatedCategoryFields(collection);
 }

--- a/src/lib/catalog/get-page-data.ts
+++ b/src/lib/catalog/get-page-data.ts
@@ -1,22 +1,44 @@
-import { PageGetBySlugDocument } from "@/gql/graphql";
+import { PageGetBySlugDocument, type LanguageCodeEnum } from "@/gql/graphql";
 import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
 import { withTranslatedPageFields } from "@/lib/saleor-translations";
 import { CACHE_PROFILES, applyCacheProfile } from "@/lib/cache-manifest";
+import { resolveByPossiblyTranslatedSlug } from "@/lib/catalog/resolve-by-slug";
+import { tagPrimaryCatalogSlug } from "@/lib/catalog/tag-primary-slug";
 
 export async function getPageData(slug: string, localeSlug: string) {
 	"use cache";
-	applyCacheProfile(CACHE_PROFILES.pages, slug);
+	const decodedSlug = decodeURIComponent(slug);
+	applyCacheProfile(CACHE_PROFILES.pages, decodedSlug);
 
-	const result = await executePublicGraphQL(PageGetBySlugDocument, {
-		variables: { slug, ...graphqlLanguageCodeVariables(localeSlug) },
+	const languageVariables = graphqlLanguageCodeVariables(localeSlug);
+
+	const fetchPage = async (vars: { slug: string; slugLanguageCode?: LanguageCodeEnum }) => {
+		const result = await executePublicGraphQL(PageGetBySlugDocument, {
+			variables: {
+				slug: vars.slug,
+				...languageVariables,
+				...(vars.slugLanguageCode ? { slugLanguageCode: vars.slugLanguageCode } : {}),
+			},
+		});
+
+		if (!result.ok) {
+			console.error(`[getPageData] Failed to fetch page ${vars.slug}:`, result.error.message);
+			return null;
+		}
+
+		return result.data.page;
+	};
+
+	const page = await resolveByPossiblyTranslatedSlug({
+		localeSlug,
+		urlSlug: decodedSlug,
+		fetchByPrimarySlug: (urlSlug) => fetchPage({ slug: urlSlug }),
+		fetchByTranslatedSlug: (urlSlug, slugLanguageCode) => fetchPage({ slug: urlSlug, slugLanguageCode }),
 	});
 
-	if (!result.ok) {
-		console.error(`[getPageData] Failed to fetch page ${slug}:`, result.error.message);
-		return null;
-	}
+	if (!page) return null;
 
-	const page = result.data.page;
-	return page ? withTranslatedPageFields(page) : null;
+	tagPrimaryCatalogSlug(CACHE_PROFILES.pages, decodedSlug, page.slug);
+	return withTranslatedPageFields(page);
 }

--- a/src/lib/catalog/get-product-data.ts
+++ b/src/lib/catalog/get-product-data.ts
@@ -1,0 +1,48 @@
+import { ProductDetailsDocument, type LanguageCodeEnum } from "@/gql/graphql";
+import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
+import { executePublicGraphQL } from "@/lib/graphql";
+import { withTranslatedProductFields } from "@/lib/saleor-translations";
+import { CACHE_PROFILES, applyCacheProfile } from "@/lib/cache-manifest";
+import { resolveByPossiblyTranslatedSlug } from "@/lib/catalog/resolve-by-slug";
+import { tagPrimaryCatalogSlug } from "@/lib/catalog/tag-primary-slug";
+
+export async function getProductData(slug: string, channel: string, localeSlug: string) {
+	"use cache";
+	const decodedSlug = decodeURIComponent(slug);
+	applyCacheProfile(CACHE_PROFILES.products, decodedSlug);
+
+	const languageVariables = graphqlLanguageCodeVariables(localeSlug);
+
+	const fetchProduct = async (vars: { slug: string; slugLanguageCode?: LanguageCodeEnum }) => {
+		const result = await executePublicGraphQL(ProductDetailsDocument, {
+			variables: {
+				slug: vars.slug,
+				channel,
+				...languageVariables,
+				...(vars.slugLanguageCode ? { slugLanguageCode: vars.slugLanguageCode } : {}),
+			},
+		});
+
+		if (!result.ok) {
+			console.error(
+				`[getProductData] Failed to fetch product ${vars.slug} for ${channel}:`,
+				result.error.message,
+			);
+			return null;
+		}
+
+		return result.data.product;
+	};
+
+	const product = await resolveByPossiblyTranslatedSlug({
+		localeSlug,
+		urlSlug: decodedSlug,
+		fetchByPrimarySlug: (urlSlug) => fetchProduct({ slug: urlSlug }),
+		fetchByTranslatedSlug: (urlSlug, slugLanguageCode) => fetchProduct({ slug: urlSlug, slugLanguageCode }),
+	});
+
+	if (!product) return null;
+
+	tagPrimaryCatalogSlug(CACHE_PROFILES.products, decodedSlug, product.slug);
+	return withTranslatedProductFields(product);
+}

--- a/src/lib/catalog/locale-slugs.test.ts
+++ b/src/lib/catalog/locale-slugs.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "./locale-slugs";
+
+describe("buildLocaleSlugMap", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("uses translated slugs per configured locale and falls back to primary", () => {
+		vi.stubEnv("NEXT_PUBLIC_STOREFRONT_LOCALES", "en,pl");
+		vi.stubEnv("NEXT_PUBLIC_DEFAULT_LOCALE", "en");
+
+		expect(
+			buildLocaleSlugMap({
+				slug: "hoodie",
+				slugEN: { slug: null },
+				slugPL: { slug: "bluza" },
+			}),
+		).toEqual({
+			en: "hoodie",
+			pl: "bluza",
+		});
+	});
+});
+
+describe("buildCatalogPathSuffixByLocale", () => {
+	it("builds encoded path suffixes per locale", () => {
+		expect(
+			buildCatalogPathSuffixByLocale("products", {
+				en: "hoodie",
+				pl: "bluza",
+			}),
+		).toEqual({
+			en: "/products/hoodie",
+			pl: "/products/bluza",
+		});
+	});
+});

--- a/src/lib/catalog/locale-slugs.ts
+++ b/src/lib/catalog/locale-slugs.ts
@@ -1,0 +1,54 @@
+import { LOCALE_DEFINITIONS, getStorefrontLocaleSlugs, type LocaleSlug } from "@/config/locale";
+import type { CatalogSlugKind } from "@/lib/catalog/catalog-identity";
+import { pickTranslatedField } from "@/lib/saleor-translations";
+
+/**
+ * Shape produced by `*LocaleSlugTranslations` GraphQL fragments.
+ * Keys are `slug` + LanguageCodeEnum (`slugEN`, `slugPL`, …).
+ */
+export type LocaleSlugTranslationFields = {
+	slug: string;
+	slugEN?: { slug?: string | null } | null;
+	slugPL?: { slug?: string | null } | null;
+	slugDE?: { slug?: string | null } | null;
+	slugFR?: { slug?: string | null } | null;
+	slugFI?: { slug?: string | null } | null;
+	slugNB?: { slug?: string | null } | null;
+};
+
+function slugAliasForLocale(locale: LocaleSlug): keyof LocaleSlugTranslationFields {
+	const code = LOCALE_DEFINITIONS[locale].graphqlLanguageCode;
+	return `slug${code}` as keyof LocaleSlugTranslationFields;
+}
+
+/**
+ * Map of storefront locale slug → canonical catalog URL slug for that language.
+ * Falls back to the primary Saleor slug when a translation slug is absent.
+ */
+export function buildLocaleSlugMap(entity: LocaleSlugTranslationFields): Record<string, string> {
+	const map: Record<string, string> = {};
+
+	for (const locale of getStorefrontLocaleSlugs()) {
+		const alias = slugAliasForLocale(locale);
+		const translation = entity[alias];
+		const translated =
+			translation && typeof translation === "object"
+				? pickTranslatedField(translation, "slug", entity.slug)
+				: entity.slug;
+		map[locale] = translated ?? entity.slug;
+	}
+
+	return map;
+}
+
+/** `/{kind}/{slug}` per locale for hreflang / language-switch targets. */
+export function buildCatalogPathSuffixByLocale(
+	kind: CatalogSlugKind,
+	localeSlugMap: Record<string, string>,
+): Record<string, string> {
+	const suffixes: Record<string, string> = {};
+	for (const [locale, slug] of Object.entries(localeSlugMap)) {
+		suffixes[locale] = `/${kind}/${encodeURIComponent(slug)}`;
+	}
+	return suffixes;
+}

--- a/src/lib/catalog/resolve-by-slug.test.ts
+++ b/src/lib/catalog/resolve-by-slug.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveByPossiblyTranslatedSlug } from "./resolve-by-slug";
+
+describe("resolveByPossiblyTranslatedSlug", () => {
+	it("prefers translated slug, then falls back to primary", async () => {
+		const fetchByPrimarySlug = vi.fn(async () => ({ id: "primary" }));
+		const fetchByTranslatedSlug = vi.fn(async () => null);
+
+		const result = await resolveByPossiblyTranslatedSlug({
+			localeSlug: "en",
+			urlSlug: "hoodie",
+			fetchByPrimarySlug,
+			fetchByTranslatedSlug,
+		});
+
+		expect(fetchByTranslatedSlug).toHaveBeenCalledWith("hoodie", "EN");
+		expect(fetchByPrimarySlug).toHaveBeenCalledWith("hoodie");
+		expect(result).toEqual({ id: "primary" });
+	});
+
+	it("returns translated match without primary lookup when found", async () => {
+		const fetchByPrimarySlug = vi.fn(async () => ({ id: "primary" }));
+		const fetchByTranslatedSlug = vi.fn(async () => ({ id: "translated" }));
+
+		const result = await resolveByPossiblyTranslatedSlug({
+			localeSlug: "pl",
+			urlSlug: "bluza",
+			fetchByPrimarySlug,
+			fetchByTranslatedSlug,
+		});
+
+		expect(result).toEqual({ id: "translated" });
+		expect(fetchByPrimarySlug).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/catalog/resolve-by-slug.ts
+++ b/src/lib/catalog/resolve-by-slug.ts
@@ -1,0 +1,27 @@
+import { getGraphqlLanguageCode } from "@/config/locale";
+import type { LanguageCodeEnum } from "@/gql/graphql";
+
+/**
+ * Resolve a catalog entity by URL slug, honoring Saleor translated slugs.
+ *
+ * Saleor does not fall back between primary and translated slug lookups — the
+ * client must try both. Prefer the translated match (SEO / locale-canonical URLs),
+ * then primary. Applies to every locale, including the default: link helpers may
+ * emit `translation.slug` whenever merchants set one.
+ *
+ * @see docs/adr/0004-translatable-slugs.md
+ */
+export async function resolveByPossiblyTranslatedSlug<T>(options: {
+	localeSlug: string;
+	urlSlug: string;
+	fetchByPrimarySlug: (slug: string) => Promise<T | null>;
+	fetchByTranslatedSlug: (slug: string, slugLanguageCode: LanguageCodeEnum) => Promise<T | null>;
+}): Promise<T | null> {
+	const { localeSlug, urlSlug, fetchByPrimarySlug, fetchByTranslatedSlug } = options;
+	const languageCode = getGraphqlLanguageCode(localeSlug) as LanguageCodeEnum;
+
+	const translated = await fetchByTranslatedSlug(urlSlug, languageCode);
+	if (translated) return translated;
+
+	return fetchByPrimarySlug(urlSlug);
+}

--- a/src/lib/catalog/tag-primary-slug.ts
+++ b/src/lib/catalog/tag-primary-slug.ts
@@ -3,7 +3,10 @@ import { type CacheProfile, buildTag } from "@/lib/cache-manifest";
 
 /**
  * When a page was fetched via a translated URL slug, also tag the entry with the
- * primary slug so PRODUCT_/CATEGORY_/… webhooks (which carry the primary slug) bust cache.
+ * primary slug so PRODUCT_/CATEGORY_/… webhooks (which carry the primary slug) bust
+ * the `"use cache"` payload. Path fan-out in `/api/revalidate` still uses the primary
+ * slug only — translated URL route shells rely on tag invalidation (+ TTL) until
+ * paper-app can forward per-locale handles (ADR 0004 phase 3).
  */
 export function tagPrimaryCatalogSlug(profile: CacheProfile, urlSlug: string, primarySlug: string) {
 	if (urlSlug === primarySlug) return;

--- a/src/lib/catalog/tag-primary-slug.ts
+++ b/src/lib/catalog/tag-primary-slug.ts
@@ -1,0 +1,11 @@
+import { cacheTag } from "next/cache";
+import { type CacheProfile, buildTag } from "@/lib/cache-manifest";
+
+/**
+ * When a page was fetched via a translated URL slug, also tag the entry with the
+ * primary slug so PRODUCT_/CATEGORY_/… webhooks (which carry the primary slug) bust cache.
+ */
+export function tagPrimaryCatalogSlug(profile: CacheProfile, urlSlug: string, primarySlug: string) {
+	if (urlSlug === primarySlug) return;
+	cacheTag(buildTag(profile, primarySlug));
+}

--- a/src/lib/graphql-locale.ts
+++ b/src/lib/graphql-locale.ts
@@ -5,3 +5,10 @@ import type { LanguageCodeEnum } from "@/gql/graphql";
 export function graphqlLanguageCodeVariables(localeSlug: string): { languageCode: LanguageCodeEnum } {
 	return { languageCode: getGraphqlLanguageCode(localeSlug) as LanguageCodeEnum };
 }
+
+/** GraphQL `slugLanguageCode` for resolving catalog entities by translated slug. */
+export function graphqlSlugLanguageCodeVariables(localeSlug: string): {
+	slugLanguageCode: LanguageCodeEnum;
+} {
+	return { slugLanguageCode: getGraphqlLanguageCode(localeSlug) as LanguageCodeEnum };
+}

--- a/src/lib/menus/menu-item-utils.ts
+++ b/src/lib/menus/menu-item-utils.ts
@@ -1,5 +1,5 @@
 import type { MenuItem } from "@/lib/menus/get-menu-data";
-import { pickTranslatedName, pickTranslatedTitle } from "@/lib/saleor-translations";
+import { pickTranslatedName, pickTranslatedSlug, pickTranslatedTitle } from "@/lib/saleor-translations";
 import { isSafeExternalHref, isSafeMailtoHref, sanitizeNavHref } from "@/lib/url/safe-href";
 
 export function getMenuItemLabel(item: MenuItem): string | null {
@@ -11,9 +11,9 @@ export function getMenuItemLabel(item: MenuItem): string | null {
 }
 
 export function getMenuItemHref(item: MenuItem): string | null {
-	if (item.category?.slug) return `/categories/${item.category.slug}`;
-	if (item.collection?.slug) return `/collections/${item.collection.slug}`;
-	if (item.page?.slug) return `/pages/${item.page.slug}`;
+	if (item.category?.slug) return `/categories/${pickTranslatedSlug(item.category)}`;
+	if (item.collection?.slug) return `/collections/${pickTranslatedSlug(item.collection)}`;
+	if (item.page?.slug) return `/pages/${pickTranslatedSlug(item.page)}`;
 	if (item.url) return sanitizeNavHref(item.url);
 	return null;
 }

--- a/src/lib/saleor-translations.test.ts
+++ b/src/lib/saleor-translations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { pickTranslatedName, withTranslatedProductFields } from "./saleor-translations";
+import { pickTranslatedName, pickTranslatedSlug, withTranslatedProductFields } from "./saleor-translations";
 
 describe("pickTranslatedName", () => {
 	it("prefers translation over default name", () => {
@@ -21,19 +21,43 @@ describe("pickTranslatedName", () => {
 	});
 });
 
+describe("pickTranslatedSlug", () => {
+	it("prefers translated slug for URLs", () => {
+		expect(
+			pickTranslatedSlug({
+				slug: "hoodie",
+				translation: { slug: "bluza" },
+			}),
+		).toBe("bluza");
+	});
+
+	it("falls back to primary slug when translation slug is empty", () => {
+		expect(
+			pickTranslatedSlug({
+				slug: "hoodie",
+				translation: { slug: "" },
+			}),
+		).toBe("hoodie");
+	});
+});
+
 describe("withTranslatedProductFields", () => {
-	it("merges product and category translations", () => {
+	it("merges product and category translations without overwriting primary slug", () => {
 		const product = withTranslatedProductFields({
 			name: "Hoodie",
-			translation: { name: "Bluza" },
+			slug: "hoodie",
+			translation: { name: "Bluza", slug: "bluza" },
 			category: {
 				name: "Apparel",
-				translation: { name: "Odzież" },
+				slug: "apparel",
+				translation: { name: "Odzież", slug: "odziez" },
 			},
 			variants: [{ name: "M", translation: { name: "Średni" } }],
 		});
 
 		expect(product.name).toBe("Bluza");
+		expect(product.slug).toBe("hoodie");
+		expect(pickTranslatedSlug(product)).toBe("bluza");
 		expect(product.category?.name).toBe("Odzież");
 		expect(product.variants?.[0]?.name).toBe("Średni");
 	});

--- a/src/lib/saleor-translations.ts
+++ b/src/lib/saleor-translations.ts
@@ -23,6 +23,19 @@ export function pickTranslatedName(entity: {
 	return pickTranslatedField(entity.translation, "name", entity.name) ?? entity.name;
 }
 
+/**
+ * Locale-canonical catalog URL slug. Keeps `entity.slug` (primary) untouched for
+ * cache tags / webhooks — use this only when building browse paths.
+ *
+ * @see docs/adr/0004-translatable-slugs.md
+ */
+export function pickTranslatedSlug(entity: {
+	slug: string;
+	translation?: { slug?: string | null } | null;
+}): string {
+	return pickTranslatedField(entity.translation, "slug", entity.slug) ?? entity.slug;
+}
+
 export function pickTranslatedTitle(entity: {
 	title: string;
 	translation?: { title?: string | null } | null;
@@ -68,6 +81,7 @@ type TranslatableCategory = {
 		description?: string | null;
 		seoTitle?: string | null;
 		seoDescription?: string | null;
+		slug?: string | null;
 	} | null;
 };
 
@@ -92,6 +106,7 @@ type TranslatablePage = {
 		content?: string | null;
 		seoTitle?: string | null;
 		seoDescription?: string | null;
+		slug?: string | null;
 	} | null;
 };
 
@@ -115,10 +130,12 @@ type TranslatableProduct = {
 		description?: string | null;
 		seoTitle?: string | null;
 		seoDescription?: string | null;
+		slug?: string | null;
 	} | null;
 	category?: {
 		name: string;
-		translation?: { name?: string | null } | null;
+		slug?: string;
+		translation?: { name?: string | null; slug?: string | null } | null;
 	} | null;
 	variants?: Array<{
 		name: string;

--- a/src/lib/seo/hreflang.test.ts
+++ b/src/lib/seo/hreflang.test.ts
@@ -30,4 +30,22 @@ describe("buildLocaleHreflangAlternates", () => {
 			"x-default": "/en/default-channel/products/hoodie",
 		});
 	});
+
+	it("uses per-locale path suffixes for translated catalog slugs", () => {
+		vi.stubEnv("NEXT_PUBLIC_STOREFRONT_LOCALES", "en,pl");
+		vi.stubEnv("NEXT_PUBLIC_DEFAULT_LOCALE", "en");
+		vi.stubEnv("NEXT_PUBLIC_DEFAULT_CHANNEL", "default-channel");
+		vi.stubEnv("STOREFRONT_CHANNELS", "default-channel");
+
+		expect(
+			buildLocaleHreflangAlternates("default-channel", {
+				en: "/products/hoodie",
+				pl: "/products/bluza",
+			}),
+		).toEqual({
+			en: "/en/default-channel/products/hoodie",
+			pl: "/pl/default-channel/products/bluza",
+			"x-default": "/en/default-channel/products/hoodie",
+		});
+	});
 });

--- a/src/lib/seo/hreflang.ts
+++ b/src/lib/seo/hreflang.ts
@@ -5,6 +5,9 @@ import { buildStorefrontPath } from "@/lib/storefront-path";
 
 type LocaleChannelTarget = { locale: string; channel: string };
 
+/** Same suffix for every locale, or a per-locale suffix map (translated catalog slugs). */
+export type HreflangPathInput = string | Record<string, string>;
+
 function getHreflangTargets(fallbackChannel: string): LocaleChannelTarget[] {
 	const pairs = getConfiguredLocaleChannelPairs();
 	if (pairs) {
@@ -27,22 +30,34 @@ function getXDefaultTarget(fallbackChannel: string): LocaleChannelTarget {
 	return { locale: defaultLocale, channel: defaultChannel };
 }
 
+function resolvePathSuffix(pathInput: HreflangPathInput, locale: string, fallbackSuffix: string): string {
+	if (typeof pathInput === "string") return pathInput;
+	return pathInput[locale] ?? pathInput[getDefaultLocaleSlug()] ?? fallbackSuffix;
+}
+
 /**
- * hreflang alternates for the same path suffix.
+ * hreflang alternates for browse URLs.
+ * Pass a single path suffix, or a per-locale map when catalog slugs are translated (ADR 0004).
  * When `NEXT_PUBLIC_STOREFRONT_LOCALE_CHANNELS` is set, each locale uses its paired channel.
  * Includes `x-default` pointing at default locale + its channel.
  */
-export function buildLocaleHreflangAlternates(channel: string, pathSuffix: string): Record<string, string> {
+export function buildLocaleHreflangAlternates(
+	channel: string,
+	pathSuffix: HreflangPathInput,
+): Record<string, string> {
 	const languages: Record<string, string> = {};
+	const fallbackSuffix = typeof pathSuffix === "string" ? pathSuffix : (Object.values(pathSuffix)[0] ?? "");
 
 	for (const { locale, channel: targetChannel } of getHreflangTargets(channel)) {
 		const definition = getLocaleDefinition(locale);
 		if (!definition) continue;
-		languages[definition.htmlLang] = buildStorefrontPath(locale, targetChannel, pathSuffix);
+		const suffix = resolvePathSuffix(pathSuffix, locale, fallbackSuffix);
+		languages[definition.htmlLang] = buildStorefrontPath(locale, targetChannel, suffix);
 	}
 
 	const xDefault = getXDefaultTarget(channel);
-	languages["x-default"] = buildStorefrontPath(xDefault.locale, xDefault.channel, pathSuffix);
+	const xDefaultSuffix = resolvePathSuffix(pathSuffix, xDefault.locale, fallbackSuffix);
+	languages["x-default"] = buildStorefrontPath(xDefault.locale, xDefault.channel, xDefaultSuffix);
 
 	return languages;
 }

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -196,12 +196,20 @@ export function buildBrowsePageMetadata(options: {
 	image?: string | null;
 	locale: string;
 	channel: string;
-	/** Path after locale/channel, e.g. `/products/hoodie` */
+	/** Path after locale/channel for this page, e.g. `/products/hoodie` */
 	pathSuffix: string;
+	/**
+	 * Optional per-locale path suffixes for hreflang (translated catalog slugs).
+	 * Canonical URL still uses `pathSuffix` for the current locale.
+	 */
+	pathSuffixByLocale?: Record<string, string>;
 	openGraph?: Record<string, string>;
 }): Metadata {
 	const url = buildStorefrontPath(options.locale, options.channel, options.pathSuffix);
-	const languages = buildLocaleHreflangAlternates(options.channel, options.pathSuffix);
+	const languages = buildLocaleHreflangAlternates(
+		options.channel,
+		options.pathSuffixByLocale ?? options.pathSuffix,
+	);
 
 	return buildPageMetadata({
 		title: options.title,

--- a/src/ui/components/footer-menu-columns.tsx
+++ b/src/ui/components/footer-menu-columns.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { MenuItem } from "@/lib/menus/get-menu-data";
+import { getMenuItemHref, getMenuItemLabel } from "@/lib/menus/menu-item-utils";
 import { LinkWithChannel } from "@/ui/atoms/link-with-channel";
 import { NavHrefLink } from "@/ui/atoms/nav-href-link";
 
@@ -19,50 +20,27 @@ const defaultFooterLinks = {
 };
 
 function FooterMenuChildLink({ child }: { child: MenuItem }) {
-	if (child.category) {
+	const href = getMenuItemHref(child);
+	const label = getMenuItemLabel(child);
+	if (!href || !label) return null;
+
+	if (child.category || child.collection || child.page) {
 		return (
 			<LinkWithChannel
-				href={`/categories/${child.category.slug}`}
+				href={href}
 				prefetch={false}
 				className="text-sm text-inverse-subtle transition-colors hover:text-inverse"
 			>
-				{child.category.name}
+				{label}
 			</LinkWithChannel>
 		);
 	}
-	if (child.collection) {
-		return (
-			<LinkWithChannel
-				href={`/collections/${child.collection.slug}`}
-				prefetch={false}
-				className="text-sm text-inverse-subtle transition-colors hover:text-inverse"
-			>
-				{child.collection.name}
-			</LinkWithChannel>
-		);
-	}
-	if (child.page) {
-		return (
-			<LinkWithChannel
-				href={`/pages/${child.page.slug}`}
-				prefetch={false}
-				className="text-sm text-inverse-subtle transition-colors hover:text-inverse"
-			>
-				{child.page.title}
-			</LinkWithChannel>
-		);
-	}
-	if (child.url) {
-		return (
-			<NavHrefLink
-				href={child.url}
-				className="text-sm text-inverse-subtle transition-colors hover:text-inverse"
-			>
-				{child.name}
-			</NavHrefLink>
-		);
-	}
-	return null;
+
+	return (
+		<NavHrefLink href={href} className="text-sm text-inverse-subtle transition-colors hover:text-inverse">
+			{label}
+		</NavHrefLink>
+	);
 }
 
 export function FooterMenuColumns({ items }: { items: MenuItem[] }) {

--- a/src/ui/components/pdp/variant-section-dynamic.tsx
+++ b/src/ui/components/pdp/variant-section-dynamic.tsx
@@ -11,6 +11,7 @@ import { CheckoutAddLineDocument } from "@/gql/graphql";
 import { executeAuthenticatedGraphQL } from "@/lib/graphql";
 import * as Checkout from "@/lib/checkout";
 import { getTranslations } from "next-intl/server";
+import { pickTranslatedSlug } from "@/lib/saleor-translations";
 
 import { AddToCart } from "./add-to-cart";
 import { VariantSelectionSection } from "./variant-selection";
@@ -168,7 +169,7 @@ export async function VariantSectionDynamic({
 				<VariantSelectionSection
 					variants={variants}
 					selectedVariantId={selectedVariantID}
-					productSlug={product.slug}
+					productSlug={pickTranslatedSlug(product)}
 					channel={channel}
 				/>
 

--- a/src/ui/components/plp/utils.ts
+++ b/src/ui/components/plp/utils.ts
@@ -5,7 +5,7 @@ import { sortSizes } from "@/lib/sizes";
 import { localeConfig, resolveLocaleFromSlug } from "@/config/locale";
 import { calculateDiscountPercent, hasDiscount, hasDiscountInPriceRange } from "@/lib/pricing";
 import { buildStorefrontPath } from "@/lib/storefront-path";
-import { pickTranslatedName } from "@/lib/saleor-translations";
+import { pickTranslatedName, pickTranslatedSlug } from "@/lib/saleor-translations";
 import { isBestseller } from "@/lib/catalog/product-flags";
 
 /**
@@ -99,7 +99,7 @@ export function toProductCardData(
 		imageAlt: product.thumbnail?.alt ?? productName,
 		hoverImage: null, // Would need additional media in fragment
 		localeBcp47: resolveLocaleFromSlug(locale).bcp47,
-		href: buildStorefrontPath(locale, channel, `/products/${product.slug}`),
+		href: buildStorefrontPath(locale, channel, `/products/${pickTranslatedSlug(product)}`),
 		badge: isSale ? "Sale" : null,
 		isBestseller: isBestseller(product),
 		colors,

--- a/src/ui/components/storefront-providers.tsx
+++ b/src/ui/components/storefront-providers.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { type ReactNode } from "react";
+import { CatalogIdentityProvider } from "@/lib/catalog/catalog-identity-bridge";
 import { CartProvider } from "@/ui/components/cart/cart-context";
 
 export function StorefrontProviders({ children }: { children: ReactNode }) {
-	return <CartProvider>{children}</CartProvider>;
+	return (
+		<CartProvider>
+			<CatalogIdentityProvider>{children}</CatalogIdentityProvider>
+		</CartProvider>
+	);
 }


### PR DESCRIPTION
* Support Saleor translated catalog slugs (product/category/collection/page): resolve via slugLanguageCode with primary fallback, canonical 308, and locale-aware links/menus.
* Language switch keeps the same entity (per-locale slug map when ready; safe fallback if chrome loads first) and preserves query params.
* Per-locale hreflang from GraphQL translation aliases (pathSuffixByLocale).
