### PR TITLE
docs: add skill for redirect urls and missing docs

### DIFF
--- a/docs/configuration/allowed-origins.md
+++ b/docs/configuration/allowed-origins.md
@@ -1,0 +1,31 @@
+# Configuring Allowed Origins
+
+Storefront uses the following sources (environment variables) to determine whether
+a given origin is allowed:
+
+- `NEXT_PUBLIC_STOREFRONT_URL` - the URL where the frontend is hosted. See other
+  relevant documents for more info.
+- `NEXT_PUBLIC_CHECKOUT_URL` - the URL where the checkout is hosted. See other documents
+  for more details.
+- `ALLOWED_EXTRA_ORIGINS` - a custom list of additional origins to allow. This is
+  comma-separated without any spaces and must contain protocol + hostname + optionally
+  the port number.
+
+  For example:
+
+  ```
+  ALLOWED_EXTRA_ORIGINS=http://localhost:3000,https://example.com
+  ```
+
+**Important:** all these variables are optional. If you are using Vercel, then
+you likely do not need to configure anything.
+
+As well as Vercel-specific sources:
+
+- [`VERCEL_PROJECT_PRODUCTION_URL`]
+- [`VERCEL_BRANCH_URL`]
+- [`VERCEL_URL`]
+
+[`VERCEL_PROJECT_PRODUCTION_URL`]: https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_PROJECT_PRODUCTION_URL
+[`VERCEL_BRANCH_URL`]: https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_BRANCH_URL
+[`VERCEL_URL`]: https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_URL

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -5,7 +5,7 @@ Saleor Paper
 June 2026
 
 > ⚠️ **Generated artifact — do not load this file in an agent session.** It concatenates
-> all 30 rules (~75k tokens) and exists only for humans reading offline and for
+> all 31 rules (~75k tokens) and exists only for humans reading offline and for
 > single-file skill export. **Agents:** read `SKILL.md`, then the **one** `rules/<task>.md`
 > whose frontmatter `description` matches the task. Never read this compiled file to "get oriented".
 >
@@ -16,7 +16,7 @@ June 2026
 
 ## Abstract
 
-Comprehensive guide for AI agents and LLMs maintaining the Saleor Paper storefront — a Next.js 16 e-commerce application with TypeScript, Tailwind CSS, and the Saleor GraphQL API. Covers 30 rules across 8 categories: architecture (canonical Next.js), data layer (caching, auth, GraphQL), product pages (PDP, variants, high-cardinality, filtering), checkout flow (surfaces, management, payments, components), design & composition (token system, design quality, section catalog, page composition, design-from-image, verification), UI & i18n, SEO, and development practices. Each rule includes architecture diagrams, code examples, file locations, and anti-patterns.
+Comprehensive guide for AI agents and LLMs maintaining the Saleor Paper storefront — a Next.js 16 e-commerce application with TypeScript, Tailwind CSS, and the Saleor GraphQL API. Covers 31 rules across 8 categories: architecture (canonical Next.js), data layer (caching, auth, GraphQL), product pages (PDP, variants, high-cardinality, filtering), checkout flow (surfaces, management, payments, components), design & composition (token system, design quality, section catalog, page composition, design-from-image, verification), UI & i18n, SEO, and development practices. Each rule includes architecture diagrams, code examples, file locations, and anti-patterns.
 
 ---
 
@@ -29,9 +29,10 @@ Comprehensive guide for AI agents and LLMs maintaining the Saleor Paper storefro
    - 1.1 [Caching Strategy](#11-caching-strategy)
    - 1.2 [GraphQL Workflow](#12-graphql-workflow)
    - 1.3 [Auth Routes (BFF)](#13-auth-routes-bff)
-   - 1.4 [Storefront Content Layer](#14-storefront-content-layer)
-   - 1.5 [Storefront Content (Saleor Models)](#15-storefront-content-saleor-models)
-   - 1.6 [Storefront Content Attributes](#16-storefront-content-attributes)
+   - 1.4 [Redirect URL Security](#14-redirect-url-security)
+   - 1.5 [Storefront Content Layer](#15-storefront-content-layer)
+   - 1.6 [Storefront Content (Saleor Models)](#16-storefront-content-saleor-models)
+   - 1.7 [Storefront Content Attributes](#17-storefront-content-attributes)
 
 2. [Product Pages](#2-product-pages) — **HIGH**
    - 2.1 [Product Detail Page](#21-product-detail-page)
@@ -666,7 +667,56 @@ Related: [`data-caching.md`](data-caching.md) (page-boundary model), [`checkout-
 
 ---
 
-### 1.4 Storefront Content Layer
+### 1.4 Redirect URL Security
+
+Redirect URLs are security-sensitive everywhere. Any code path that accepts, builds, validates, stores, forwards, or follows a redirect URL must treat the destination origin as attacker-controlled until it has passed the shared allowlist check.
+
+## Rule
+
+Production redirect allowlists must come from explicit configuration, not request metadata.
+
+The allowed origin sources are documented in `docs/configuration/allowed-origins.md`; do NOT copy that list into other code; always reuse `isAllowedRedirectUrl()` for redirect destination checks. Do not duplicate its parsing, normalization, environment handling, or development fallback logic in route handlers, Server Actions, components, or tests.
+
+## Never Trust These For Production Allowlisting
+
+Do not allow these values to introduce a production redirect origin:
+
+- `Host`
+- `X-Forwarded-Host`
+- `X-Forwarded-Proto`
+- `Origin`
+- `Referer`
+- `request.nextUrl.origin`
+- `headers().get(...)`
+- helper output derived from request headers, including `getRequestOrigin()`
+
+## Saleor Boundary
+
+Saleor also validates these redirect URLs with [`ALLOWED_CLIENT_HOSTS`]. Keep storefront allowlists aligned with Saleor config, but do not rely on Saleor as the only guard. The storefront check should reject invalid redirect origins before forwarding the mutation.
+
+[`ALLOWED_CLIENT_HOSTS`]: https://docs.saleor.io/setup/configuration#allowed_client_hosts
+
+## Required Tests
+
+When changing redirect validation, auth routes, or checkout auth actions, add or keep tests that prove:
+
+- A redirect URL matching only `request.nextUrl.origin` or `getRequestOrigin()` is rejected in production.
+- Spoofed `Host` or `X-Forwarded-*` derived origins do not become allowed production origins.
+- Configured storefront, checkout, and extra origins are accepted.
+- Loopback request origins are accepted only outside production.
+- Foreign origins, subdomain tricks, non-http schemes, protocol-relative URLs, and malformed URLs are rejected.
+
+## Anti-patterns
+
+- Do not use `allowed.push(request.nextUrl.origin)`
+- Do not use `allowed.push(await getRequestOrigin())`
+- Do not treat `Origin` as a redirect allowlist source.
+- Do not fix failing tests by broadening the allowlist to request headers.
+- Do not add preview or deployment hosts implicitly unless the helper already supports that exact env source.
+
+---
+
+### 1.5 Storefront Content Layer
 
 Marketing and merchandising copy (announcement bar, homepage sections, cart trust labels, checkout empty states) lives in a **provider-agnostic content layer** — separate from catalog data, menus, and transactional checkout state.
 
@@ -830,7 +880,7 @@ Marketing copy is cached like navigation; cart/checkout **transactional** data s
 
 ---
 
-### 1.5 Storefront Content (Saleor Models)
+### 1.6 Storefront Content (Saleor Models)
 
 Paper models merchandising copy in **Saleor Models** (PageTypes + Pages + page-type attributes) and the storefront maps those Pages into the normalized `StorefrontContent` shape. This rule is the Saleor side — provider behavior, merge, and the code/Saleor scope split are in [`data-storefront-content.md`](data-storefront-content.md); attribute types in [`data-storefront-content-attributes.md`](data-storefront-content-attributes.md).
 
@@ -939,7 +989,7 @@ Storefront content is cached under `storefront-content:{channel}:{locale}` and f
 
 ---
 
-### 1.6 Storefront Content Attributes
+### 1.7 Storefront Content Attributes
 
 How to choose Saleor attribute `inputType`s on storefront Models, and what Paper reads today.
 

--- a/skills/saleor-paper-storefront/README.md
+++ b/skills/saleor-paper-storefront/README.md
@@ -32,12 +32,12 @@ npx skills add saleor/agent-skills --skill saleor-storefront
 
 ## What's Included
 
-30 rules across 8 categories covering the full storefront:
+31 rules across 8 categories covering the full storefront:
 
 | Category      | Rules                                                                                                                                                 | Topics                                                            |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | Architecture  | `paper-architecture`                                                                                                                                  | Canonical Next.js stance, pillar index, deliberate non-goals      |
-| Data Layer    | `data-caching`, `data-auth-routes`, `data-graphql`, `data-storefront-content`, `data-storefront-content-saleor`, `data-storefront-content-attributes` | Cache, auth, GraphQL, merchandising copy, Models, attribute types |
+| Data Layer    | `data-caching`, `data-auth-routes`, `data-redirect-security`, `data-graphql`, `data-storefront-content`, `data-storefront-content-saleor`, `data-storefront-content-attributes` | Cache, auth, GraphQL, merchandising copy, Models, attribute types |
 | Product Pages | `product-pdp`, `product-variants`, `product-high-cardinality`, `product-filtering`                                                                    | PDP architecture, variant selection, high-cardinality caps/facets |
 | Checkout      | `paper-surfaces`, `checkout-design-principles`, `checkout-management`, `checkout-payment-gateways`, `checkout-components`                             | Checkout v2, UX principles, lifecycle, payments, UI               |
 | UI & Channels | `ui-components`, `ui-channels`, `ui-locale-routing`, `ui-i18n`                                                                                        | Design tokens, multi-currency, locale URLs, next-intl messages    |

--- a/skills/saleor-paper-storefront/SKILL.md
+++ b/skills/saleor-paper-storefront/SKILL.md
@@ -17,7 +17,7 @@ dependencies:
 
 Project-specific guide for the Saleor Paper storefront — a Next.js 16 e-commerce
 application with TypeScript, Tailwind CSS, and the Saleor GraphQL API. Contains
-30 rules across 8 categories covering architecture, caching, storefront content, PDP architecture, checkout v2,
+31 rules across 8 categories covering architecture, caching, storefront content, PDP architecture, checkout v2,
 design & composition (token system, design quality, section catalog, page composition, design-from-image, verification),
 components, UI patterns, locale routing, i18n, and SEO.
 
@@ -69,6 +69,7 @@ Reference these guidelines when:
 
 - `data-caching` - Cache Components (PPR), three-layer page model, cache manifest, webhooks
 - `data-auth-routes` - BFF auth, `resolveSessionUser`, account PPR, header chrome refresh
+- `data-redirect-security` - Redirect URL allowlists for auth emails, checkout/account flows, and Host/Origin spoofing prevention
 - `data-graphql` - Two codegen setups (checkout types via server actions, not urql runtime)
 - `data-storefront-content` - Provider-agnostic copy layer, merge semantics, cache tags, wiring
 - `data-storefront-content-saleor` - Saleor Models, slug stack, channel overrides, Configurator

--- a/skills/saleor-paper-storefront/rules/data-redirect-security.md
+++ b/skills/saleor-paper-storefront/rules/data-redirect-security.md
@@ -1,0 +1,51 @@
+---
+name: data-redirect-security
+description: Redirect URL security for auth emails and checkout/account flows: isAllowedRedirectUrl, redirectUrl, password reset, account confirmation, Host/Origin/X-Forwarded spoofing, NEXT_PUBLIC_STOREFRONT_URL, ALLOWED_EXTRA_ORIGINS, Saleor ALLOWED_CLIENT_HOSTS. Use when touching redirect allowlists or URLs sent to Saleor mutations.
+---
+
+# Redirect URL Security
+
+Redirect URLs are security-sensitive everywhere. Any code path that accepts, builds, validates, stores, forwards, or follows a redirect URL must treat the destination origin as attacker-controlled until it has passed the shared allowlist check.
+
+## Rule
+
+Production redirect allowlists must come from explicit configuration, not request metadata.
+
+The allowed origin sources are documented in `docs/configuration/allowed-origins.md`; do NOT copy that list into other code; always reuse `isAllowedRedirectUrl()` for redirect destination checks. Do not duplicate its parsing, normalization, environment handling, or development fallback logic in route handlers, Server Actions, components, or tests.
+
+## Never Trust These For Production Allowlisting
+
+Do not allow these values to introduce a production redirect origin:
+
+- `Host`
+- `X-Forwarded-Host`
+- `X-Forwarded-Proto`
+- `Origin`
+- `Referer`
+- `request.nextUrl.origin`
+- `headers().get(...)`
+- helper output derived from request headers, including `getRequestOrigin()`
+
+## Saleor Boundary
+
+Saleor also validates these redirect URLs with [`ALLOWED_CLIENT_HOSTS`]. Keep storefront allowlists aligned with Saleor config, but do not rely on Saleor as the only guard. The storefront check should reject invalid redirect origins before forwarding the mutation.
+
+[`ALLOWED_CLIENT_HOSTS`]: https://docs.saleor.io/setup/configuration#allowed_client_hosts
+
+## Required Tests
+
+When changing redirect validation, auth routes, or checkout auth actions, add or keep tests that prove:
+
+- A redirect URL matching only `request.nextUrl.origin` or `getRequestOrigin()` is rejected in production.
+- Spoofed `Host` or `X-Forwarded-*` derived origins do not become allowed production origins.
+- Configured storefront, checkout, and extra origins are accepted.
+- Loopback request origins are accepted only outside production.
+- Foreign origins, subdomain tricks, non-http schemes, protocol-relative URLs, and malformed URLs are rejected.
+
+## Anti-patterns
+
+- Do not use `allowed.push(request.nextUrl.origin)`
+- Do not use `allowed.push(await getRequestOrigin())`
+- Do not treat `Origin` as a redirect allowlist source.
+- Do not fix failing tests by broadening the allowlist to request headers.
+- Do not add preview or deployment hosts implicitly unless the helper already supports that exact env source.

--- a/skills/saleor-paper-storefront/scripts/compile-agents.mjs
+++ b/skills/saleor-paper-storefront/scripts/compile-agents.mjs
@@ -12,7 +12,7 @@ const skillRoot = join(__dirname, "..");
 const rulesDir = join(skillRoot, "rules");
 const outPath = join(skillRoot, "AGENTS.md");
 
-const RULE_COUNT = 30;
+const RULE_COUNT = 31;
 
 const catalog = [
 	{
@@ -33,9 +33,10 @@ const catalog = [
 			{ num: "1.1", file: "data-caching.md", title: "Caching Strategy" },
 			{ num: "1.2", file: "data-graphql.md", title: "GraphQL Workflow" },
 			{ num: "1.3", file: "data-auth-routes.md", title: "Auth Routes (BFF)" },
-			{ num: "1.4", file: "data-storefront-content.md", title: "Storefront Content Layer" },
-			{ num: "1.5", file: "data-storefront-content-saleor.md", title: "Storefront Content (Saleor Models)" },
-			{ num: "1.6", file: "data-storefront-content-attributes.md", title: "Storefront Content Attributes" },
+			{ num: "1.4", file: "data-redirect-security.md", title: "Redirect URL Security" },
+			{ num: "1.5", file: "data-storefront-content.md", title: "Storefront Content Layer" },
+			{ num: "1.6", file: "data-storefront-content-saleor.md", title: "Storefront Content (Saleor Models)" },
+			{ num: "1.7", file: "data-storefront-content-attributes.md", title: "Storefront Content Attributes" },
 		],
 	},
 	{

--- a/skills/saleor-paper-storefront/scripts/ensure-rule-frontmatter.mjs
+++ b/skills/saleor-paper-storefront/scripts/ensure-rule-frontmatter.mjs
@@ -40,6 +40,8 @@ const DESCRIPTIONS = {
 		"GraphQL codegen workflow: edit src/graphql/*.graphql or src/checkout/graphql/*.graphql then run pnpm generate / generate:checkout. Use when adding GraphQL fields, hitting missing generated types, permission errors, or the assignedAttribute API.",
 	"data-auth-routes.md":
 		"BFF auth and PPR-safe account routes: /api/auth/*, HttpOnly cookies, resolveSessionUser, header chrome refresh. Use when touching login/session, account pages, or fixing 'uncached data outside Suspense' on routes that read cookies.",
+	"data-redirect-security.md":
+		"Redirect URL security for auth emails and checkout/account flows: isAllowedRedirectUrl, redirectUrl, password reset, account confirmation, Host/Origin/X-Forwarded spoofing, NEXT_PUBLIC_STOREFRONT_URL, ALLOWED_EXTRA_ORIGINS, Saleor ALLOWED_CLIENT_HOSTS. Use when touching redirect allowlists or URLs sent to Saleor mutations.",
 	"data-storefront-content.md":
 		"Provider-agnostic marketing/merchandising copy layer (announcement bar, homepage, cart/checkout copy): getStorefrontContent, defaults.ts, merge semantics, CONTENT_PROVIDER. Use when editing editorial copy or wiring new content fields.",
 	"data-storefront-content-saleor.md":


### PR DESCRIPTION
Follow-up for eddfc4e89b91f2c7a84e9b098283877493fd8623:
- Adds the missing git-tracked file `docs/configuration/allowed-origins.md`
- Adds a skill (`skills/saleor-paper-storefront/rules/data-redirect-security.md`) that guides agents into not repeating their mistakes around origin URLs and any other redirects