### PR TITLE
feat(accounts): add password confirmation for sign-up

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -282,14 +282,17 @@
 			"redirecting": "Sie werden zum Shop weitergeleitet…"
 		},
 		"confirm": {
-			"confirmingTitle": "Konto wird bestätigt",
-			"confirmingBody": "{email} wird verifiziert…",
 			"successTitle": "Konto bestätigt",
-			"successBody": "Ihr Konto für {email} ist aktiv. Melden Sie sich mit dem von Ihnen erstellten Passwort an.",
+			"successBody": "Ihr Konto für {email} ist aktiv.",
 			"signIn": "Anmelden",
 			"continueShopping": "Weiter einkaufen",
 			"errorTitle": "Konto konnte nicht bestätigt werden",
-			"goToSignIn": "Zur Anmeldung"
+			"goToSignIn": "Zur Anmeldung",
+			"title": "Konto bestätigen",
+			"body": "Geben Sie das Passwort für {email} ein, um Ihr Konto zu bestätigen.",
+			"submit": "Konto bestätigen",
+			"submitting": "Wird bestätigt…",
+			"tryAgain": "Erneut versuchen"
 		},
 		"nav": {
 			"ariaLabel": "Konto",

--- a/messages/en.json
+++ b/messages/en.json
@@ -282,14 +282,17 @@
 			"redirecting": "Redirecting you to the store…"
 		},
 		"confirm": {
-			"confirmingTitle": "Confirming your account",
-			"confirmingBody": "Verifying {email}…",
 			"successTitle": "Account confirmed",
-			"successBody": "Your account for {email} is active. Sign in with the password you created.",
+			"successBody": "Your account for {email} is active.",
 			"signIn": "Sign in",
 			"continueShopping": "Continue shopping",
 			"errorTitle": "Couldn't confirm account",
-			"goToSignIn": "Go to sign in"
+			"goToSignIn": "Go to sign in",
+			"title": "Confirm your account",
+			"body": "Enter the password for {email} to finish confirming your account.",
+			"submit": "Confirm account",
+			"submitting": "Confirming…",
+			"tryAgain": "Try again"
 		},
 		"nav": {
 			"ariaLabel": "Account",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -282,14 +282,17 @@
 			"redirecting": "Ohjataan kauppaan…"
 		},
 		"confirm": {
-			"confirmingTitle": "Vahvistetaan tiliä",
-			"confirmingBody": "Vahvistetaan {email}…",
 			"successTitle": "Tili vahvistettu",
-			"successBody": "Tilisi osoitteelle {email} on aktiivinen. Kirjaudu sisään luomallasi salasanalla.",
+			"successBody": "Tilisi osoitteelle {email} on aktiivinen.",
 			"signIn": "Kirjaudu sisään",
 			"continueShopping": "Jatka ostoksia",
-			"errorTitle": "Tilin vahvistaminen epäonnistui",
-			"goToSignIn": "Siirry kirjautumiseen"
+			"errorTitle": "Tiliä ei voitu vahvistaa",
+			"goToSignIn": "Siirry kirjautumiseen",
+			"title": "Vahvista tilisi",
+			"body": "Viimeistele tilisi vahvistus antamalla salasanasi osoitteelle {email}.",
+			"submit": "Vahvista tili",
+			"submitting": "Vahvistetaan…",
+			"tryAgain": "Yritä uudelleen"
 		},
 		"nav": {
 			"ariaLabel": "Tili",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -282,14 +282,17 @@
 			"redirecting": "Redirection vers la boutique…"
 		},
 		"confirm": {
-			"confirmingTitle": "Confirmation de votre compte",
-			"confirmingBody": "Vérification de {email}…",
 			"successTitle": "Compte confirmé",
-			"successBody": "Votre compte pour {email} est actif. Connectez-vous avec le mot de passe que vous avez créé.",
+			"successBody": "Votre compte pour {email} est actif.",
 			"signIn": "Se connecter",
-			"continueShopping": "Continuer mes achats",
+			"continueShopping": "Continuer vos achats",
 			"errorTitle": "Impossible de confirmer le compte",
-			"goToSignIn": "Aller à la connexion"
+			"goToSignIn": "Aller à la connexion",
+			"title": "Confirmer votre compte",
+			"body": "Saisissez le mot de passe de {email} pour terminer la confirmation de votre compte.",
+			"submit": "Confirmer le compte",
+			"submitting": "Confirmation…",
+			"tryAgain": "Réessayer"
 		},
 		"nav": {
 			"ariaLabel": "Compte",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -282,14 +282,17 @@
 			"redirecting": "ストアへ移動しています…"
 		},
 		"confirm": {
-			"confirmingTitle": "アカウントを確認しています",
-			"confirmingBody": "{email} を確認中…",
 			"successTitle": "アカウントを確認しました",
-			"successBody": "{email} のアカウントが有効になりました。作成したパスワードでサインインしてください。",
+			"successBody": "{email} のアカウントが有効になりました。",
 			"signIn": "サインイン",
 			"continueShopping": "買い物を続ける",
 			"errorTitle": "アカウントを確認できませんでした",
-			"goToSignIn": "サインインへ"
+			"goToSignIn": "サインインへ",
+			"title": "アカウントを確認",
+			"body": "{email} のパスワードを入力して、アカウント確認を完了してください。",
+			"submit": "アカウントを確認",
+			"submitting": "確認中…",
+			"tryAgain": "再試行"
 		},
 		"nav": {
 			"ariaLabel": "アカウント",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -273,14 +273,17 @@
 			"redirecting": "스토어로 이동 중…"
 		},
 		"confirm": {
-			"confirmingTitle": "계정을 확인하는 중",
-			"confirmingBody": "{email} 확인 중…",
 			"successTitle": "계정이 확인되었습니다",
-			"successBody": "{email} 계정이 활성화되었습니다. 생성한 비밀번호로 로그인하세요.",
+			"successBody": "{email} 계정이 활성화되었습니다.",
 			"signIn": "로그인",
 			"continueShopping": "쇼핑 계속하기",
 			"errorTitle": "계정을 확인할 수 없습니다",
-			"goToSignIn": "로그인하러 가기"
+			"goToSignIn": "로그인으로 이동",
+			"title": "계정 확인",
+			"body": "{email}의 비밀번호를 입력해 계정 확인을 완료하세요.",
+			"submit": "계정 확인",
+			"submitting": "확인 중…",
+			"tryAgain": "다시 시도"
 		},
 		"nav": {
 			"ariaLabel": "계정",

--- a/messages/nb.json
+++ b/messages/nb.json
@@ -282,14 +282,17 @@
 			"redirecting": "Omdirigerer deg til butikken…"
 		},
 		"confirm": {
-			"confirmingTitle": "Bekrefter kontoen din",
-			"confirmingBody": "Verifiserer {email}…",
 			"successTitle": "Konto bekreftet",
-			"successBody": "Kontoen din for {email} er aktiv. Logg inn med passordet du opprettet.",
+			"successBody": "Kontoen din for {email} er aktiv.",
 			"signIn": "Logg inn",
 			"continueShopping": "Fortsett å handle",
 			"errorTitle": "Kunne ikke bekrefte konto",
-			"goToSignIn": "Gå til innlogging"
+			"goToSignIn": "Gå til innlogging",
+			"title": "Bekreft kontoen din",
+			"body": "Skriv inn passordet for {email} for å fullføre bekreftelsen av kontoen.",
+			"submit": "Bekreft konto",
+			"submitting": "Bekrefter…",
+			"tryAgain": "Prøv igjen"
 		},
 		"nav": {
 			"ariaLabel": "Konto",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -282,14 +282,17 @@
 			"redirecting": "Przekierowujemy do sklepu…"
 		},
 		"confirm": {
-			"confirmingTitle": "Potwierdzanie konta",
-			"confirmingBody": "Weryfikacja {email}…",
 			"successTitle": "Konto potwierdzone",
-			"successBody": "Twoje konto dla {email} jest aktywne. Zaloguj się hasłem, które utworzyłeś.",
+			"successBody": "Twoje konto dla {email} jest aktywne.",
 			"signIn": "Zaloguj się",
 			"continueShopping": "Kontynuuj zakupy",
 			"errorTitle": "Nie udało się potwierdzić konta",
-			"goToSignIn": "Przejdź do logowania"
+			"goToSignIn": "Przejdź do logowania",
+			"title": "Potwierdź konto",
+			"body": "Wpisz hasło dla {email}, aby dokończyć potwierdzanie konta.",
+			"submit": "Potwierdź konto",
+			"submitting": "Potwierdzanie…",
+			"tryAgain": "Spróbuj ponownie"
 		},
 		"nav": {
 			"ariaLabel": "Konto",

--- a/src/app/api/auth/confirm-account/route.ts
+++ b/src/app/api/auth/confirm-account/route.ts
@@ -6,6 +6,7 @@ import { confirmAccountWithToken } from "@/lib/auth/confirm-account";
 interface ConfirmAccountRequest {
 	email: string;
 	token: string;
+	password: string;
 }
 
 export async function POST(request: NextRequest) {
@@ -27,16 +28,16 @@ export async function POST(request: NextRequest) {
 		);
 	}
 
-	const { email, token } = body;
+	const { email, token, password } = body;
 
-	if (!email || !token) {
+	if (!email || !token || !password) {
 		return NextResponse.json(
-			{ errors: [{ message: "Email and token are required", code: "REQUIRED" }] },
+			{ errors: [{ message: "Email, token, and password are required", code: "REQUIRED" }] },
 			{ status: 400 },
 		);
 	}
 
-	const result = await confirmAccountWithToken(email, token);
+	const result = await confirmAccountWithToken(email, token, password);
 
 	if (!result.ok) {
 		return NextResponse.json({ errors: result.errors }, { status: httpStatusForAuthErrors(result.errors) });

--- a/src/lib/auth/bff-client.ts
+++ b/src/lib/auth/bff-client.ts
@@ -33,11 +33,15 @@ export async function loginWithBff(email: string, password: string): Promise<Aut
 	return data;
 }
 
-export async function confirmAccountWithBff(email: string, token: string): Promise<AuthApiResponse> {
+export async function confirmAccountWithBff(
+	email: string,
+	token: string,
+	password: string,
+): Promise<AuthApiResponse> {
 	const response = await fetch("/api/auth/confirm-account", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ email, token }),
+		body: JSON.stringify({ email, token, password }),
 		credentials: "same-origin",
 	});
 

--- a/src/lib/auth/confirm-account-client.ts
+++ b/src/lib/auth/confirm-account-client.ts
@@ -5,14 +5,18 @@ type ConfirmBffResponse = Awaited<ReturnType<typeof confirmAccountWithBff>>;
 const inflight = new Map<string, Promise<ConfirmBffResponse>>();
 
 /** Dedupes concurrent calls (e.g. React Strict Mode double-mount in dev). */
-export function confirmAccountWithBffDeduped(email: string, token: string): Promise<ConfirmBffResponse> {
+export function confirmAccountWithBffDeduped(
+	email: string,
+	token: string,
+	password: string,
+): Promise<ConfirmBffResponse> {
 	const key = `${email}:${token}`;
 	const existing = inflight.get(key);
 	if (existing) {
 		return existing;
 	}
 
-	const request = confirmAccountWithBff(email, token).finally(() => {
+	const request = confirmAccountWithBff(email, token, password).finally(() => {
 		inflight.delete(key);
 	});
 

--- a/src/lib/auth/confirm-account.test.ts
+++ b/src/lib/auth/confirm-account.test.ts
@@ -26,7 +26,12 @@ describe("confirmAccountWithToken", () => {
 			},
 		});
 
-		await expect(confirmAccountWithToken("user@example.com", "token")).resolves.toEqual({ ok: true });
+		await expect(confirmAccountWithToken("user@example.com", "token", "secret")).resolves.toEqual({ ok: true });
+		expect(executeRawGraphQL).toHaveBeenCalledWith(
+			expect.objectContaining({
+				variables: { email: "user@example.com", token: "token", password: "secret" },
+			}),
+		);
 	});
 
 	it("maps Saleor validation errors", async () => {
@@ -40,7 +45,7 @@ describe("confirmAccountWithToken", () => {
 			},
 		});
 
-		await expect(confirmAccountWithToken("user@example.com", "bad")).resolves.toEqual({
+		await expect(confirmAccountWithToken("user@example.com", "bad", "secret")).resolves.toEqual({
 			ok: false,
 			errors: [{ message: "Invalid token", code: "INVALID_TOKEN" }],
 		});

--- a/src/lib/auth/confirm-account.ts
+++ b/src/lib/auth/confirm-account.ts
@@ -5,8 +5,8 @@ import type { AuthApiError } from "./auth-api-types";
 import { executeRawGraphQL } from "@/lib/graphql";
 
 const CONFIRM_ACCOUNT_MUTATION = `
-  mutation ConfirmAccount($email: String!, $token: String!) {
-    confirmAccount(email: $email, token: $token) {
+  mutation ConfirmAccount($email: String!, $token: String!, $password: String!) {
+    confirmAccount(email: $email, token: $token, password: $password) {
       user {
         id
         email
@@ -33,10 +33,11 @@ type ConfirmAccountResult = {
 export async function confirmAccountWithToken(
 	email: string,
 	token: string,
+	password: string,
 ): Promise<{ ok: true } | { ok: false; errors: AuthApiError[] }> {
 	const result = await executeRawGraphQL<ConfirmAccountResult>({
 		query: CONFIRM_ACCOUNT_MUTATION,
-		variables: { email, token },
+		variables: { email, token, password },
 	});
 
 	if (!result.ok) {

--- a/src/ui/components/auth/confirm-account-mode.tsx
+++ b/src/ui/components/auth/confirm-account-mode.tsx
@@ -3,14 +3,22 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { CheckCircle, Loader2, Mail } from "lucide-react";
+import { CheckCircle, Eye, EyeOff, Lock, Mail } from "lucide-react";
 import { confirmAccountWithBffDeduped } from "@/lib/auth/confirm-account-client";
 import { buildStorefrontPath } from "@/lib/storefront-path";
-import { buttonClassName } from "@/ui/components/ui/button";
+import { Button, buttonClassName } from "@/ui/components/ui/button";
+import { Input } from "@/ui/components/ui/input";
+import { Label } from "@/ui/components/ui/label";
 
-type ConfirmState = "confirming" | "success" | "error";
+type ConfirmState = "form" | "success" | "error";
 
-type ConfirmErrorKey = "invalidConfirmToken" | "confirmFailed";
+type ConfirmErrorKey =
+	| "invalidConfirmToken"
+	| "confirmFailed"
+	| "passwordRequired"
+	| "invalidCredentials"
+	| "resetLinkFailed"
+	| "generic";
 
 type Props = {
 	email: string;
@@ -33,7 +41,13 @@ export function ConfirmAccountMode({
 	continueShoppingHref,
 }: Props) {
 	const t = useTranslations("account");
-	const [state, setState] = useState<ConfirmState>("confirming");
+	const [state, setState] = useState<ConfirmState>("form");
+	const [password, setPassword] = useState("");
+	const [showPassword, setShowPassword] = useState(false);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [isResettingPassword, setIsResettingPassword] = useState(false);
+	const [resetEmailSent, setResetEmailSent] = useState(false);
+	const [resetMessage, setResetMessage] = useState("");
 	const [errorKey, setErrorKey] = useState<ConfirmErrorKey | null>(null);
 	const onConfirmedRef = useRef(onConfirmed);
 
@@ -44,24 +58,37 @@ export function ConfirmAccountMode({
 		onConfirmedRef.current = onConfirmed;
 	}, [onConfirmed]);
 
-	useEffect(() => {
-		let cancelled = false;
+	async function handleConfirm(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+		setErrorKey(null);
 
-		async function run() {
-			const result = await confirmAccountWithBffDeduped(email, token);
+		if (!password) {
+			setErrorKey("passwordRequired");
+			return;
+		}
 
-			if (cancelled) {
-				return;
-			}
+		setIsSubmitting(true);
+
+		try {
+			const result = await confirmAccountWithBffDeduped(email, token, password);
 
 			if (result.errors?.length) {
 				const err = result.errors[0];
-				if (err.code === "INVALID_TOKEN" || err.message?.toLowerCase().includes("token")) {
+				const message = err.message?.toLowerCase() ?? "";
+				const code = err.code ?? "";
+
+				if (code === "INVALID_TOKEN" || message.includes("token")) {
 					setErrorKey("invalidConfirmToken");
-				} else {
-					setErrorKey("confirmFailed");
+					setState("error");
+					return;
 				}
-				setState("error");
+
+				if (code === "INVALID_CREDENTIALS" || code === "INVALID_PASSWORD" || message.includes("password")) {
+					setErrorKey("invalidCredentials");
+					return;
+				}
+
+				setErrorKey("confirmFailed");
 				return;
 			}
 
@@ -73,30 +100,47 @@ export function ConfirmAccountMode({
 
 			setErrorKey("confirmFailed");
 			setState("error");
+		} catch {
+			setErrorKey("generic");
+		} finally {
+			setIsSubmitting(false);
 		}
+	}
 
-		void run();
+	async function handleForgotPassword() {
+		setErrorKey(null);
+		setResetMessage("");
+		setIsResettingPassword(true);
 
-		return () => {
-			cancelled = true;
-		};
-	}, [email, token]);
+		try {
+			const response = await fetch("/api/auth/reset-password", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				credentials: "same-origin",
+				body: JSON.stringify({
+					email,
+					channel,
+					redirectUrl: new URL(loginHref, window.location.origin).toString(),
+				}),
+			});
+
+			const data = (await response.json()) as { errors?: Array<{ message: string }>; success?: boolean };
+
+			if (!response.ok || data.errors?.length) {
+				setErrorKey("resetLinkFailed");
+				return;
+			}
+
+			setResetEmailSent(true);
+			setResetMessage(t("login.resetSent", { email }));
+		} catch {
+			setErrorKey("generic");
+		} finally {
+			setIsResettingPassword(false);
+		}
+	}
 
 	const errorMessage = errorKey ? t(`errors.${errorKey}`) : "";
-
-	if (state === "confirming") {
-		return (
-			<div className="mx-auto my-16 w-full max-w-md">
-				<div className="rounded-lg border border-border bg-card p-8 shadow-sm">
-					<div className="flex flex-col items-center gap-4 text-center">
-						<Loader2 className="h-10 w-10 animate-spin text-muted-foreground" aria-hidden />
-						<h1 className="text-balance text-h1">{t("confirm.confirmingTitle")}</h1>
-						<p className="text-sm text-muted-foreground">{t("confirm.confirmingBody", { email })}</p>
-					</div>
-				</div>
-			</div>
-		);
-	}
 
 	if (state === "success") {
 		return (
@@ -129,34 +173,108 @@ export function ConfirmAccountMode({
 		);
 	}
 
+	if (state === "error") {
+		return (
+			<div className="mx-auto my-16 w-full max-w-md">
+				<div className="rounded-lg border border-border bg-card p-8 shadow-sm">
+					<div className="flex flex-col items-center gap-4 text-center">
+						<div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+							<Mail className="h-8 w-8 text-muted-foreground" aria-hidden />
+						</div>
+						<h1 className="text-balance text-h1">{t("confirm.errorTitle")}</h1>
+						<p role="alert" className="text-sm text-destructive">
+							{errorMessage}
+						</p>
+						<Button
+							type="button"
+							variant="outline-solid"
+							className="h-12 w-full text-base font-semibold"
+							onClick={() => {
+								setState("form");
+								setErrorKey(null);
+							}}
+						>
+							{t("confirm.tryAgain")}
+						</Button>
+						<Link
+							href={storeHref}
+							className="text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground hover:no-underline"
+						>
+							{t("confirm.continueShopping")}
+						</Link>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
 	return (
 		<div className="mx-auto my-16 w-full max-w-md">
 			<div className="rounded-lg border border-border bg-card p-8 shadow-sm">
-				<div className="flex flex-col items-center gap-4 text-center">
-					<div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-						<Mail className="h-8 w-8 text-muted-foreground" aria-hidden />
-					</div>
-					<h1 className="text-balance text-h1">{t("confirm.errorTitle")}</h1>
-					<p role="alert" className="text-sm text-destructive">
-						{errorMessage}
-					</p>
-					<Link
-						href={loginHref}
-						className={buttonClassName({
-							variant: "outline-solid",
-							asLink: true,
-							className: "h-12 w-full text-base font-semibold",
-						})}
-					>
-						{t("confirm.goToSignIn")}
-					</Link>
-					<Link
-						href={storeHref}
-						className="text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground hover:no-underline"
-					>
-						{t("confirm.continueShopping")}
-					</Link>
+				<div className="mb-6 text-center">
+					<h1 className="text-balance text-h1">{t("confirm.title")}</h1>
+					<p className="mt-2 text-sm text-muted-foreground">{t("confirm.body", { email })}</p>
 				</div>
+
+				<form onSubmit={handleConfirm} className="space-y-4">
+					{errorKey && (
+						<div role="alert" className="bg-destructive/10 rounded-md p-3 text-sm text-destructive">
+							{errorMessage}
+						</div>
+					)}
+
+					{resetMessage && (
+						<div role="status" className="rounded-md bg-muted p-3 text-sm text-muted-foreground">
+							{resetMessage}
+						</div>
+					)}
+
+					<div className="space-y-1.5">
+						<Label htmlFor="confirm-account-password" className="text-sm font-medium">
+							{t("fields.password")}
+						</Label>
+						<div className="relative">
+							<Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								id="confirm-account-password"
+								type={showPassword ? "text" : "password"}
+								placeholder={t("placeholders.password")}
+								autoComplete="current-password"
+								value={password}
+								onChange={(event) => setPassword(event.target.value)}
+								className="h-12 pl-10 pr-10"
+								required
+							/>
+							<button
+								type="button"
+								onClick={() => setShowPassword(!showPassword)}
+								aria-label={showPassword ? t("common.hidePassword") : t("common.showPassword")}
+								className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+							>
+								{showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+							</button>
+						</div>
+					</div>
+
+					<div className="flex justify-end">
+						<button
+							type="button"
+							onClick={() => void handleForgotPassword()}
+							disabled={isSubmitting || isResettingPassword || resetEmailSent}
+							className="text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground hover:no-underline disabled:opacity-50"
+						>
+							{t("login.forgotPassword")}
+						</button>
+					</div>
+
+					<Button
+						type="submit"
+						disabled={isSubmitting || isResettingPassword}
+						className="h-12 w-full text-base font-semibold"
+					>
+						{isSubmitting ? t("confirm.submitting") : t("confirm.submit")}
+					</Button>
+				</form>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
This adds a new `password` input field when activating the account which implements the upgrade notes from https://docs.saleor.io/upgrade-guides/core/migrate-account-merging

Note: this accepts any password by default, this is normal. As per the upgrade guide: `accountConfirmMergeMode` must be set to `REQUIRE_PASSWORD` for the `password` input to be checked
