### PR TITLE
fix: always allow loopback redirects

### DIFF
--- a/src/app/(checkout)/actions.ts
+++ b/src/app/(checkout)/actions.ts
@@ -88,7 +88,7 @@ import { getCheckoutServerTranslations } from "@/checkout/lib/server/get-checkou
 import { toCheckoutActionResult } from "@/checkout/lib/server/mutation-result";
 import { toTypedDocument } from "@/checkout/lib/server/to-typed-document";
 import { checkoutGraphqlLanguageCode } from "@/lib/checkout-locale";
-import { getRequestOrigin, isAllowedRedirectUrl } from "@/lib/auth/validate-redirect-url";
+import { isAllowedRedirectUrl } from "@/lib/auth/validate-redirect-url";
 import { executeAuthenticatedGraphQL, executePublicGraphQL, executeRawGraphQL } from "@/lib/graphql";
 import * as Checkout from "@/lib/checkout";
 import { saveCheckoutId } from "@/app/actions";
@@ -276,7 +276,7 @@ export async function registerCheckoutAccount(input: {
 	redirectUrl: string;
 }): Promise<SimpleActionResult> {
 	// Confirmation emails embed this URL — reject foreign origins (phishing vector).
-	if (!isAllowedRedirectUrl(input.redirectUrl, await getRequestOrigin())) {
+	if (!isAllowedRedirectUrl(input.redirectUrl)) {
 		const { server: t } = await getCheckoutServerTranslations();
 		console.warn(
 			"Received an invalid redirection URL for password reset. " +
@@ -681,7 +681,7 @@ export async function requestCheckoutPasswordReset(input: {
 	redirectUrl: string;
 }): Promise<SimpleActionResult> {
 	// Reset emails embed this URL — reject foreign origins (phishing vector).
-	if (!isAllowedRedirectUrl(input.redirectUrl, await getRequestOrigin())) {
+	if (!isAllowedRedirectUrl(input.redirectUrl)) {
 		const { server: t } = await getCheckoutServerTranslations();
 		console.warn(
 			"Received an invalid redirection URL for password reset. " +

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: NextRequest) {
 	}
 
 	// Confirmation emails embed this URL — only this deployment's surfaces are allowed.
-	if (redirectUrl && !isAllowedRedirectUrl(redirectUrl, request.nextUrl.origin)) {
+	if (redirectUrl && !isAllowedRedirectUrl(redirectUrl)) {
 		console.warn(
 			"Received an invalid redirection URL for password reset. " +
 				"Make sure to configure NEXT_PUBLIC_STOREFRONT_URL, " +

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest) {
 	}
 
 	// Reset emails embed this URL — only this deployment's surfaces are allowed.
-	if (!isAllowedRedirectUrl(redirectUrl, request.nextUrl.origin)) {
+	if (!isAllowedRedirectUrl(redirectUrl)) {
 		console.warn(
 			"Received an invalid redirection URL for password reset. " +
 				"Make sure to configure NEXT_PUBLIC_STOREFRONT_URL, " +

--- a/src/lib/auth/validate-redirect-url.test.ts
+++ b/src/lib/auth/validate-redirect-url.test.ts
@@ -39,66 +39,70 @@ describe("isAllowedRedirectUrl", () => {
 		restoreEnv("ALLOWED_EXTRA_ORIGINS", ORIGINAL_ALLOWED_EXTRA_ORIGINS);
 	});
 
-	it("rejects URLs that only match the request origin in production", () => {
+	it("rejects unconfigured URLs in production", () => {
 		// Production mode should reject
-		expect(
-			isAllowedRedirectUrl("https://shop.example.com/checkout?checkout=abc", "https://shop.example.com"),
-		).toBe(false);
+		expect(isAllowedRedirectUrl("https://shop.example.com/checkout?checkout=abc")).toBe(false);
 	});
 
 	it("rejects URLs on a foreign origin", () => {
 		process.env.NEXT_PUBLIC_STOREFRONT_URL = "https://shop.example.com";
 
-		expect(isAllowedRedirectUrl("https://evil.example.com/reset", "https://shop.example.com")).toBe(false);
+		expect(isAllowedRedirectUrl("https://evil.example.com/reset")).toBe(false);
 	});
 
 	it("rejects subdomain and scheme tricks", () => {
 		process.env.NEXT_PUBLIC_STOREFRONT_URL = "https://shop.example.com";
 
-		expect(isAllowedRedirectUrl("https://shop.example.com.evil.com/x", null)).toBe(false);
-		expect(isAllowedRedirectUrl("javascript:alert(1)", null)).toBe(false);
-		expect(isAllowedRedirectUrl("//evil.example.com/x", null)).toBe(false);
-		expect(isAllowedRedirectUrl("not a url", null)).toBe(false);
+		expect(isAllowedRedirectUrl("https://shop.example.com.evil.com/x")).toBe(false);
+		expect(isAllowedRedirectUrl("javascript:alert(1)")).toBe(false);
+		expect(isAllowedRedirectUrl("//evil.example.com/x")).toBe(false);
+		expect(isAllowedRedirectUrl("not a url")).toBe(false);
 	});
 
 	it("accepts configured storefront and checkout origins", () => {
 		process.env.NEXT_PUBLIC_STOREFRONT_URL = "https://store.example.com";
 		process.env.NEXT_PUBLIC_CHECKOUT_URL = "https://pay.example.com/checkout";
 
-		expect(isAllowedRedirectUrl("https://store.example.com/login", null)).toBe(true);
-		expect(isAllowedRedirectUrl("https://pay.example.com/checkout?step=contact", null)).toBe(true);
-		expect(isAllowedRedirectUrl("https://other.example.com/login", null)).toBe(false);
+		expect(isAllowedRedirectUrl("https://store.example.com/login")).toBe(true);
+		expect(isAllowedRedirectUrl("https://pay.example.com/checkout?step=contact")).toBe(true);
+		expect(isAllowedRedirectUrl("https://other.example.com/login")).toBe(false);
 	});
 
 	it("accepts explicitly configured extra origins", () => {
 		process.env.ALLOWED_EXTRA_ORIGINS = "https://preview.example.com,https://checkout-preview.example.com";
 
-		expect(isAllowedRedirectUrl("https://preview.example.com/login", null)).toBe(true);
-		expect(isAllowedRedirectUrl("https://checkout-preview.example.com/checkout", null)).toBe(true);
-		expect(isAllowedRedirectUrl("https://not-allowed.example.com/login", null)).toBe(false);
+		expect(isAllowedRedirectUrl("https://preview.example.com/login")).toBe(true);
+		expect(isAllowedRedirectUrl("https://checkout-preview.example.com/checkout")).toBe(true);
+		expect(isAllowedRedirectUrl("https://not-allowed.example.com/login")).toBe(false);
 	});
 
-	it("accepts loopback request origins outside production", () => {
+	it("accepts loopback redirect origins outside production", () => {
 		setNodeEnv("development");
 
-		expect(isAllowedRedirectUrl("http://localhost:3000/login", "http://localhost:3000")).toBe(true);
-		expect(isAllowedRedirectUrl("http://127.0.0.1:3000/login", "http://127.0.0.1:3000")).toBe(true);
-		expect(isAllowedRedirectUrl("http://[::1]:3000/login", "http://[::1]:3000")).toBe(true);
+		expect(isAllowedRedirectUrl("http://localhost:3000/login")).toBe(true);
+		expect(isAllowedRedirectUrl("http://127.0.0.1:3000/login")).toBe(true);
+		expect(isAllowedRedirectUrl("http://[::1]:3000/login")).toBe(true);
 	});
 
-	it("rejects loopback request origins in production", () => {
-		expect(isAllowedRedirectUrl("http://localhost:3000/login", "http://localhost:3000")).toBe(false);
-		expect(isAllowedRedirectUrl("http://127.0.0.1:3000/login", "http://127.0.0.1:3000")).toBe(false);
-		expect(isAllowedRedirectUrl("http://[::1]:3000/login", "http://[::1]:3000")).toBe(false);
-	});
-
-	it("rejects arbitrary request origins outside production", () => {
+	it("accepts the IPv4 loopback confirmation redirect outside production", () => {
 		setNodeEnv("development");
 
-		expect(isAllowedRedirectUrl("https://shop.example.com/reset", "https://shop.example.com")).toBe(false);
+		expect(isAllowedRedirectUrl("http://127.0.0.1:3030/en/default-channel/login?confirm=1")).toBe(true);
+	});
+
+	it("rejects loopback redirect origins in production", () => {
+		expect(isAllowedRedirectUrl("http://localhost:3000/login")).toBe(false);
+		expect(isAllowedRedirectUrl("http://127.0.0.1:3000/login")).toBe(false);
+		expect(isAllowedRedirectUrl("http://[::1]:3000/login")).toBe(false);
+	});
+
+	it("rejects arbitrary non-loopback origins outside production", () => {
+		setNodeEnv("development");
+
+		expect(isAllowedRedirectUrl("https://shop.example.com/reset")).toBe(false);
 	});
 
 	it("rejects everything when no origins are known", () => {
-		expect(isAllowedRedirectUrl("https://shop.example.com/reset", null)).toBe(false);
+		expect(isAllowedRedirectUrl("https://shop.example.com/reset")).toBe(false);
 	});
 });

--- a/src/lib/auth/validate-redirect-url.ts
+++ b/src/lib/auth/validate-redirect-url.ts
@@ -1,5 +1,3 @@
-import { headers } from "next/headers";
-
 /**
  * Server-side allowlist for `redirectUrl` values forwarded to Saleor
  * (account confirmation and password reset emails). Clients send
@@ -56,10 +54,10 @@ function isLoopbackOrigin(origin: string): boolean {
 
 /**
  * True when `redirectUrl` is http(s) and its origin matches a configured
- * storefront/checkout/extra origin. In development, loopback request origins
+ * storefront/checkout/extra origin. In development, loopback redirect origins
  * are also accepted for local auth flows.
  */
-export function isAllowedRedirectUrl(redirectUrl: string, requestOrigin?: string | null): boolean {
+export function isAllowedRedirectUrl(redirectUrl: string): boolean {
 	let parsed: URL;
 	try {
 		parsed = new URL(redirectUrl);
@@ -74,31 +72,11 @@ export function isAllowedRedirectUrl(redirectUrl: string, requestOrigin?: string
 	const allowed = configuredOrigins();
 
 	// When in development mode, allows redirecting to localhost
-	// IMPORTANT: this only uses requestOrigin when not in production,
-	//            and uses an allow-list (doesn't allow everything/anything),
+	// IMPORTANT: this only allows loopback origins when not in production.
 	//            This shouldn't be changed as this could allow spoofing.
-	if (process.env.NODE_ENV !== "production" && requestOrigin && isLoopbackOrigin(requestOrigin)) {
-		allowed.push(requestOrigin);
+	if (process.env.NODE_ENV !== "production" && isLoopbackOrigin(parsed.origin)) {
+		allowed.push(parsed.origin);
 	}
 
 	return allowed.includes(parsed.origin);
-}
-
-/**
- * Origin of the current request as the server sees it (proxy-aware).
- * Works in both route handlers and server actions.
- */
-export async function getRequestOrigin(): Promise<string | null> {
-	const headerStore = await headers();
-	const host = headerStore.get("x-forwarded-host") ?? headerStore.get("host");
-
-	if (!host) {
-		return null;
-	}
-
-	const forwardedProto = headerStore.get("x-forwarded-proto")?.split(",")[0]?.trim();
-	const isLocalHost = host.startsWith("localhost") || host.startsWith("127.");
-	const proto = forwardedProto || (isLocalHost ? "http" : "https");
-
-	return `${proto}://${host}`;
 }


### PR DESCRIPTION
This fixes `pnpm dev` rejecting `http://localhost:3030` as a redirect URL when the origin is `http://127.0.0.1:3030`

This was caused by `http://localhost:3030` being the default redirect URL when running `next dev` due to `--hostname` flag being omitted. The issue is resolved by allowing all looback addresses in development mode which avoids requiring developers to set `--hostname` as this could lead to integration issues where one place may pass `localhost` (e.g., an app) while we expect `127.0.0.1`