### PR TITLE
Improve cost control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,5 +115,11 @@ CONTENT_PROVIDER=saleor
 # would only add latency you pay for. Raise it if Saleor rate-limits your live traffic.
 # SALEOR_MIN_REQUEST_DELAY_MS=0
 
+# Discovering channels queries Saleor during generateStaticParams and then prerenders
+# every locale x channel pair, so build minutes and prerendered output grow with the
+# product of both. An explicit STOREFRONT_CHANNELS allowlist is the cheaper default;
+# only opt in when the channel list genuinely changes without a deploy.
+# STOREFRONT_DISCOVER_CHANNELS=true
+
 # Max concurrent Saleor GraphQL requests per instance (default 3).
 # SALEOR_MAX_CONCURRENT_REQUESTS=3

--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,13 @@ CONTENT_PROVIDER=saleor
 # money against freshness — see skills/saleor-paper-storefront/rules/data-caching.md
 # § Cost controls and rules/ui-images.md for the reasoning.
 
+# Which pipeline serves catalog images. Default `saleor`: PLP cards and the PDP gallery
+# render a plain <img srcset> against Saleor's CloudFront-backed thumbnails, so those
+# images never touch /_next/image and are never billed as transformations. Set to
+# `vercel` to route everything back through next/image without a code change — the
+# escape hatch if your Saleor deployment does not front media with a CDN.
+# NEXT_PUBLIC_PAPER_IMAGE_PIPELINE=saleor
+
 # Extra hostnames /_next/image is allowed to optimize (comma-separated, no scheme).
 # Saleor Cloud hosts and the NEXT_PUBLIC_SALEOR_API_URL host are always allowed.
 # Anything listed here can be optimized at your expense — keep it tight.

--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,29 @@ CONTENT_PROVIDER=saleor
 
 # Checkout contact step — "Email me with news and offers" (on by default; persisted as checkout metadata).
 # NEXT_PUBLIC_ENABLE_CHECKOUT_MARKETING_OPT_IN=false
+
+# ---------------------------------------------------------------------------
+# Cost controls (Vercel)
+# ---------------------------------------------------------------------------
+# Paper's defaults are tuned for a production catalogue. Each knob below trades
+# money against freshness — see skills/saleor-paper-storefront/rules/data-caching.md
+# § Cost controls and rules/ui-images.md for the reasoning.
+
+# Extra hostnames /_next/image is allowed to optimize (comma-separated, no scheme).
+# Saleor Cloud hosts and the NEXT_PUBLIC_SALEOR_API_URL host are always allowed.
+# Anything listed here can be optimized at your expense — keep it tight.
+# IMAGE_ALLOWED_HOSTS=cdn.example.com,assets.example.com
+
+# How long Vercel keeps an optimized image before re-optimizing it (seconds).
+# Default 2678400 (31 days). Saleor thumbnail URLs are stable, so this is nearly free —
+# but replacing an image *in place* in Saleor reuses the URL, so the old bytes serve
+# until this expires. Lower it if the catalogue is re-shot often.
+# NEXT_IMAGE_MIN_CACHE_TTL=2678400
+
+# Forced delay between Saleor GraphQL requests (ms). Defaults to 200 during `next build`
+# (where generateStaticParams can trip Saleor's rate limiter) and 0 at runtime, where it
+# would only add latency you pay for. Raise it if Saleor rate-limits your live traffic.
+# SALEOR_MIN_REQUEST_DELAY_MS=0
+
+# Max concurrent Saleor GraphQL requests per instance (default 3).
+# SALEOR_MAX_CONCURRENT_REQUESTS=3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Paper rules are **authoritative on architecture**: Server Components by default,
 - **Product:** `product-pdp`, `product-variants`, `product-high-cardinality`, `product-filtering`
 - **Checkout:** `paper-surfaces`, `checkout-design-principles`, `checkout-management`, `checkout-payment-gateways`, `checkout-components`
 - **Design:** `ui-design-system`, `design-quality-rubric`, `ui-sections`, `page-composition`, `design-from-image`, `design-verification`
-- **UI & channels:** `ui-components`, `ui-channels`, `ui-locale-routing`, `ui-i18n`
+- **UI & channels:** `ui-components`, `ui-images`, `ui-channels`, `ui-locale-routing`, `ui-i18n`
 - **SEO:** `seo-metadata`
 - **Dev:** `dev-local`, `dev-investigation`, `third-party-embeds`
 - **Fork upgrades:** `skills/saleor-paper-storefront/migrations/SKILL.md` (triggers: "upgrade Paper", "apply Paper migrations")

--- a/README.md
+++ b/README.md
@@ -256,6 +256,35 @@ Without webhooks? TTL handles it—cached data expires per the `catalog` / `menu
 
 ---
 
+## Image Pipeline
+
+Saleor already returns a compressed, format-converted thumbnail from a CDN. Re-encoding that through Next's image optimizer is paid work that buys nothing, so Paper asks Saleor for **several sizes at once** and hands the browser a real `srcset`:
+
+```graphql
+thumbnail(size: 1024, format: WEBP) { url alt }
+thumbnail256: thumbnail(size: 256, format: WEBP) { url }
+thumbnail512: thumbnail(size: 512, format: WEBP) { url }
+```
+
+Product cards and the PDP gallery render those through [`<SaleorImage>`](src/ui/atoms/saleor-image.tsx) as a plain `<img srcset sizes>`, so they never hit `/_next/image` and are never billed as image transformations. Anything without a Saleor size ladder — CMS uploads, local assets — falls back to `next/image` automatically.
+
+|                        | Saleor-native `srcset`     | `next/image`                                                           |
+| ---------------------- | -------------------------- | ---------------------------------------------------------------------- |
+| Used for               | Product cards, PDP gallery | CMS uploads, local assets, slots far below the smallest requested size |
+| Transformations billed | none                       | one per `(src, width, quality)`                                        |
+| Served by              | Saleor's CDN               | `/_next/image`                                                         |
+
+Set `NEXT_PUBLIC_PAPER_IMAGE_PIPELINE=vercel` to route everything back through `next/image` without a code change — the escape hatch if your Saleor deployment doesn't front media with a CDN.
+
+Two things to know before going to production:
+
+- **Newly requested sizes start as redirects.** Until a thumbnail exists, Saleor returns a `/thumbnail/{id}/{size}/{format}/` proxy URL that 302s to storage, generating the file on first hit. Cached pages therefore embed redirect URLs right after you add a size, costing one extra round trip per image. It self-heals — once the file exists, the next GraphQL resolve returns the storage URL and the next re-render bakes it in — but on a large catalog, crawl it before cutting traffic over so shoppers don't pay for the warm-up.
+- **Every `thumbnail` selection needs `size:` and `format:`.** A bare `thumbnail { url }` resolves to 256px in the image's _original_ format, which puts the format conversion back on your bill.
+
+> 📚 **Deep dive**: [`skills/saleor-paper-storefront/rules/ui-images.md`](skills/saleor-paper-storefront/rules/ui-images.md) covers the Saleor thumbnail mechanics, the `sizes` vocabulary, and the anti-patterns.
+
+---
+
 ## Quick Start
 
 > [!NOTE]
@@ -391,6 +420,12 @@ SALEOR_APP_TOKEN=                                    # Server-side: footer chann
 STOREFRONT_DISCOVER_CHANNELS=true                    # Opt-in: discover ALL active Saleor channels from API
                                                      # (not recommended when Saleor has many channels; prefer STOREFRONT_CHANNELS)
 CONTENT_PROVIDER=saleor                              # Default: Saleor Models. Set `code` for code defaults only.
+
+# Cost controls — each trades money against freshness. See .env.example for the full reasoning.
+NEXT_PUBLIC_PAPER_IMAGE_PIPELINE=saleor              # `vercel` routes catalog images back through /_next/image
+IMAGE_ALLOWED_HOSTS=                                 # Extra hosts /_next/image may optimize (and bill you for)
+NEXT_IMAGE_MIN_CACHE_TTL=2678400                     # 31 days; lower it if the catalogue is re-shot often
+SALEOR_MIN_REQUEST_DELAY_MS=0                        # Runtime GraphQL throttle; defaults to 200 during `next build`
 ```
 
 **Channel resolution order** (`getStorefrontChannelSlugs`):

--- a/docs/vercel-cost-optimization.md
+++ b/docs/vercel-cost-optimization.md
@@ -204,6 +204,12 @@ difference between a handful of listing regenerations a day and tens of thousand
 
 Event names are verifiable against `saleor/webhook/event_types.py` (`WebhookEventAsyncType`).
 
+If you use [saleor-paper-app](https://github.com/saleor/saleor-paper-app), the storefront only
+sees `saleor-event` after you deploy an app version that forwards the header and click **Sync
+Webhooks**. Until then every app POST is header-less and still busts the listing tag — including
+stock. Do not subscribe the app to `PRODUCT_MEDIA_*`; Saleor already emits `PRODUCT_UPDATED` for
+media edits, and a second delivery would double the purge.
+
 ## 7. Raise the catalog revalidate backstop
 
 If webhooks are wired up they are your freshness mechanism, and `revalidate` is only the safety net

--- a/docs/vercel-cost-optimization.md
+++ b/docs/vercel-cost-optimization.md
@@ -9,18 +9,27 @@ structural one. Items 6–11 are caching and compute.
 
 ## Why these specific things
 
-Vercel bills four meters that a storefront can blow up without noticing:
+These are the meters this guide is written against. Rates are **iad1 Pro on-demand** — the
+cheapest published region, confirmed against Vercel's docs in August 2026. EU and APAC run
+higher (transformations up to $0.0812 / 1K, cache writes up to $6.40 / 1M). Enterprise
+contracts and the pre-2025 “source images” image plan can differ.
 
-| Meter                           | Rate (iad1)                  | What drives it                                  |
-| ------------------------------- | ---------------------------- | ----------------------------------------------- |
-| Image transformations           | $0.05 / 1K                   | source images × candidate widths × cache misses |
-| Image cache writes              | $4.00 / 1M units (8 KB)      | same, weighted by output bytes                  |
-| ISR writes                      | $4.00 / 1M units (8 KB)      | every regeneration of a cached route            |
-| Fast Data Transfer              | $0.15 / GB over 1 TB         | every byte Vercel serves, images included       |
-| Active CPU / Provisioned Memory | $0.128 / hr, $0.0106 / GB-hr | render time, plus I/O wait for memory           |
+| Meter                           | Rate (iad1)                  | What drives it                                                 |
+| ------------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| Image transformations           | $0.05 / 1K                   | billed on cache MISS and STALE, per (source × width × quality) |
+| Image cache writes              | $4.00 / 1M units (8 KB)      | same events, weighted by output bytes                          |
+| ISR writes                      | $4.00 / 1M units (8 KB)      | every regeneration of a cached route                           |
+| Fast Data Transfer              | $0.15 / GB over 1 TB         | every byte Vercel serves, including `/_next/image` responses   |
+| Active CPU / Provisioned Memory | $0.128 / hr, $0.0106 / GB-hr | CPU while code runs; memory for the whole instance lifetime    |
 
-The trap is that the first two scale with **catalog size × widths**, not with traffic. A fork with
-20K products pays for image work whether or not anyone visits.
+Image cache reads, ISR reads, Edge Requests, and function invocations are real meters too.
+They are usually smaller on this workload, so they stay off the table.
+
+The trap on the first two: they scale with **distinct (source × width) pairs that get
+requested at least once per TTL window** — a shopper, a crawler, or prerender. No request,
+no transformation. A 20K-SKU catalog does not generate a bill by existing. What it does is
+multiply how many of those pairs _can_ be hit, and a 4-hour TTL means a pair that is hit
+even once a window can be re-derived ~180 times a month.
 
 ## Checklist
 
@@ -44,9 +53,11 @@ The trap is that the first two scale with **catalog size × widths**, not with t
 
 ## 1. Raise `minimumCacheTTL`
 
-Next's default is 4 hours. A product photo that never changes is therefore re-transformed up to
-**180 times a month** — each one a billed transformation plus a billed cache write. Saleor
-thumbnail URLs are content-addressed and stable, so there is no reason to re-derive them.
+Next's default is 4 hours. A variant that is requested at least once per window can be
+re-transformed up to **~180 times a month** (31 days × 24 h / 4 h) — each one a billed
+transformation plus a billed cache write. Idle images cost nothing. Saleor thumbnail URLs
+are stable per (media id, size, format), so there is no reason to re-derive a pair that
+already exists.
 
 ```js
 // next.config.js
@@ -300,10 +311,9 @@ Expect a short list, and read it carefully — **every line is a component still
 On Paper's own build exactly one source survives: the homepage hero, which renders a raw CMS upload
 rather than a `thumbnail()` field and so has no rung set to request.
 
-Then compare a full billing cycle before and after on four meters in the Vercel dashboard: Image
-Optimization transformations, ISR writes, Active CPU, and Fast Data Transfer. The one to watch in
-week one is transformations. If the count does not collapse, something is still routing catalog
-images through the optimizer.
+Then compare a full billing cycle before and after on Image Optimization transformations, ISR
+writes, Active CPU, and Fast Data Transfer. The one to watch in week one is transformations. If
+the count does not collapse, something is still routing catalog images through the optimizer.
 
 ### The silent fallback trap
 

--- a/docs/vercel-cost-optimization.md
+++ b/docs/vercel-cost-optimization.md
@@ -1,0 +1,344 @@
+# Cutting Vercel cost on a Saleor storefront
+
+A migration checklist for anyone running a Next.js + Saleor storefront on Vercel. Every item
+below shipped on Paper's `feat/better-cost-control` branch; file paths reference Paper, but the
+reasoning applies to any fork.
+
+Ordered by leverage. Items 1–4 are one-line config changes worth doing today. Item 5 is the
+structural one. Items 6–11 are caching and compute.
+
+## Why these specific things
+
+Vercel bills four meters that a storefront can blow up without noticing:
+
+| Meter                           | Rate (iad1)                  | What drives it                                  |
+| ------------------------------- | ---------------------------- | ----------------------------------------------- |
+| Image transformations           | $0.05 / 1K                   | source images × candidate widths × cache misses |
+| Image cache writes              | $4.00 / 1M units (8 KB)      | same, weighted by output bytes                  |
+| ISR writes                      | $4.00 / 1M units (8 KB)      | every regeneration of a cached route            |
+| Fast Data Transfer              | $0.15 / GB over 1 TB         | every byte Vercel serves, images included       |
+| Active CPU / Provisioned Memory | $0.128 / hr, $0.0106 / GB-hr | render time, plus I/O wait for memory           |
+
+The trap is that the first two scale with **catalog size × widths**, not with traffic. A fork with
+20K products pays for image work whether or not anyone visits.
+
+## Checklist
+
+```
+[ ]  1. minimumCacheTTL: 4h -> 31 days
+[ ]  2. Every Saleor thumbnail/url selection passes size: and format: WEBP
+[ ]  3. Trim deviceSizes / imageSizes, and formats: ["image/webp"]
+[ ]  4. Replace remotePatterns "**" with an explicit host allowlist
+[ ]  5. Serve catalog images from Saleor's CDN via <img srcset>, not /_next/image
+[ ]  6. Scope webhook invalidation by the saleor-event header; never default-purge
+[ ]  7. Raise the catalog revalidate backstop from 60s to 1h
+[ ]  8. Cache the listing grids (PLP / category / collection)
+[ ]  9. Disable the build-time GraphQL throttle at runtime
+[ ] 10. Exclude /api, static assets, and other surfaces from the middleware matcher
+[ ] 11. Stop prefetching every link
+[ ] 12. Check for duplicate webhook subscriptions (Saleor app + direct)
+[ ] 13. Audit every remaining next/image call site for Saleor-backed sources
+```
+
+---
+
+## 1. Raise `minimumCacheTTL`
+
+Next's default is 4 hours. A product photo that never changes is therefore re-transformed up to
+**180 times a month** — each one a billed transformation plus a billed cache write. Saleor
+thumbnail URLs are content-addressed and stable, so there is no reason to re-derive them.
+
+```js
+// next.config.js
+images: {
+  minimumCacheTTL: 2678400, // 31 days
+}
+```
+
+Single highest-value line in this document. Vercel recommends it in their own cost guide.
+
+## 2. Never select a bare `thumbnail { url }`
+
+Without arguments, Saleor returns the **original upload** in its original format — frequently a
+2–4 MB 4096px PNG. Vercel then downloads and transcodes that on every cache miss, and you pay for
+the bytes twice.
+
+```graphql
+# Bad — original upload, original format
+thumbnail { url }
+
+# Good
+thumbnail(size: 256, format: WEBP) { url }
+```
+
+Audit every `thumbnail` and `media { url }` selection in your `.graphql` files, including the ones
+in checkout and order fragments that nobody looks at. Sizing category/collection `backgroundImage`
+matters most — those are full-bleed heroes fed from the largest originals.
+
+> **Saleor snaps to the nearest rung, not the next one up.** The ladder is
+> `32, 64, 128, 256, 512, 1024, 2048, 4096`. Asking for `300` returns `256`. Only ever request
+> values from that list, or the width you asked for is not the width you get.
+
+## 3. Trim the width ladders
+
+Every width in `deviceSizes` and `imageSizes` that a `sizes` attribute can select is a separately
+billed transformation per source image. The defaults include 2048 and 3840, which only serve 4K
+and retina-desktop, and which cost the most to produce and store.
+
+```js
+// next.config.js
+images: {
+  formats: ["image/webp"],           // AVIF cold-encodes add ~500ms+ to first hit, hurting LCP
+  deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+  imageSizes: [64, 96, 128, 256, 384],
+}
+```
+
+While you are here, check that each call site's `sizes` matches its actual layout. A half-width
+panel declaring `100vw` requests double the pixels it displays, at every breakpoint.
+
+## 4. Lock down `remotePatterns`
+
+A wildcard host pattern turns your optimizer into an open image proxy that anyone can bill you for.
+
+```js
+const imageRemotePatterns = [
+	{ protocol: "https", hostname: new URL(process.env.NEXT_PUBLIC_SALEOR_API_URL).hostname },
+	...(process.env.IMAGE_ALLOWED_HOSTS?.split(",")
+		.map((h) => h.trim())
+		.filter(Boolean)
+		.map((hostname) => ({ hostname })) ?? []),
+];
+```
+
+Keep the env var **without** a `NEXT_PUBLIC_` prefix — it is read at build time and should never
+be inlined into a client bundle.
+
+## 5. Skip the optimizer for catalog images
+
+Items 1–4 make the optimizer cheaper. This one removes it from the hot path.
+
+Saleor already produces a correctly-sized, CloudFront-cached WebP for every rung you request.
+Sending that through `/_next/image` pays for a transformation that re-derives a file you already
+have. Request several rungs as aliased fields and build the `srcset` yourself:
+
+```graphql
+thumbnail(size: 1024, format: WEBP) { url alt }
+thumbnail256: thumbnail(size: 256, format: WEBP) { url }
+thumbnail512: thumbnail(size: 512, format: WEBP) { url }
+```
+
+```ts
+export function buildSaleorSrcSet(entries: readonly { width: number; url?: string | null }[]) {
+	const seen = new Set<number>();
+	const candidates: string[] = [];
+	for (const { width, url } of entries) {
+		if (!url || seen.has(width)) continue;
+		seen.add(width);
+		candidates.push(`${url} ${width}w`);
+	}
+	// Fewer than two candidates tells the browser nothing that `src` doesn't.
+	return candidates.length > 1 ? candidates.join(", ") : undefined;
+}
+```
+
+Then render a plain `<img>` when a rung set exists, and fall back to `next/image` when it does not
+(local assets, CMS uploads). Paper's version is `src/ui/atoms/saleor-image.tsx`.
+
+Three consequences to handle, or this trades cost for a worse LCP:
+
+- **Images become cross-origin.** Under `next/image` they rode the connection the document already
+  opened. Add `<link rel="preconnect">` for the Saleor media origin in your root layout.
+- **`priority` no longer implies a preload.** `next/image` emits one; a plain `<img>` does not.
+  Call `preload(src, { as: "image", imageSrcSet, imageSizes, fetchPriority: "high" })` from
+  `react-dom` for the LCP image.
+- **New rungs 302-redirect on first request** while Saleor generates them, then serve directly
+  forever after. Self-healing, but on a large catalog consider warming the new sizes before the
+  cutover.
+
+Gate it behind an env var so a fork can revert without a code change:
+
+```ts
+export const IMAGE_PIPELINE: "saleor" | "vercel" =
+	process.env.NEXT_PUBLIC_IMAGE_PIPELINE === "vercel" ? "vercel" : "saleor";
+```
+
+**Trade-off:** three rungs per product instead of one is real thumbnail-generation load on Saleor.
+You are moving cost off Vercel, not eliminating it — though Saleor generates each rung once and
+serves it from CloudFront thereafter.
+
+## 6. Scope webhook invalidation to the event that fired
+
+The common bug is a `switch` whose `default` branch purges the product listing. Any unrecognised or
+malformed delivery then invalidates every listing route in every locale, repeatedly.
+
+Drive invalidation off Saleor's `saleor-event` header and treat the mapping as an allowlist —
+anything absent is logged and skipped. Then split events by whether they can change a listing card:
+
+```ts
+// Changes a card: bust the listing tag.
+product_created, product_updated, product_deleted,
+product_media_created / _updated / _deleted,
+product_variant_discounted_price_updated
+
+// Cannot change a card, and fires orders of magnitude more often: PDP tag only.
+product_metadata_updated,
+product_variant_created / _updated / _deleted / _metadata_updated,
+product_variant_out_of_stock, product_variant_back_in_stock,
+product_variant_stock_updated, *_in_channel, *_for_click_and_collect
+```
+
+Inventory sync must not cost a listing cache entry. On a store with live stock feeds this is the
+difference between a handful of listing regenerations a day and tens of thousands.
+
+Event names are verifiable against `saleor/webhook/event_types.py` (`WebhookEventAsyncType`).
+
+## 7. Raise the catalog revalidate backstop
+
+If webhooks are wired up they are your freshness mechanism, and `revalidate` is only the safety net
+for a webhook that was never configured or got dropped. A 60-second backstop means a cached entry
+regenerates up to 1,440 times a day regardless of traffic.
+
+```js
+catalog: {
+  stale: 5 * MINUTE,
+  revalidate: 1 * HOUR,   // was 1 * MINUTE
+  expire: 1 * DAY,
+}
+```
+
+Worth understanding why this is not a small change: at a 60-second window and moderate per-entry
+traffic, nearly every request finds the entry stale, so the cache does almost no work and you pay a
+regeneration plus an ISR write for most requests.
+
+## 8. Cache the listing grids
+
+Check whether your PLP, category, and collection grids are cached at all — in many forks they are
+not, so every request pays a full GraphQL round trip plus a full render. That cost scales linearly
+with traffic.
+
+The reason forks skip it is filter and pagination combinatorics. Cache an allowlist of views
+instead: unfiltered, first page, sort-only. Those are the ones that get crawled and shared, and
+they are a small bounded set. Everything else falls through to a live render.
+
+One correctness note: have the cached function **throw** when the GraphQL call fails, rather than
+returning `null`. Otherwise a transient upstream blip caches a 404 for the whole TTL. Reserve
+`null` for genuinely absent entities.
+
+## 9. Turn off the GraphQL throttle at runtime
+
+Storefronts often carry an inter-request delay so `generateStaticParams` does not trip Saleor's
+rate limiter during `next build`. At runtime the concurrency cap already bounds pressure, so the
+delay only adds latency — and on Fluid Compute you pay for that wall time as Provisioned Memory,
+which bills during I/O wait.
+
+```ts
+const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
+
+new RequestQueue(
+	parseInt(process.env.SALEOR_MAX_CONCURRENT_REQUESTS || "3", 10),
+	parseInt(process.env.SALEOR_MIN_REQUEST_DELAY_MS || (isBuildPhase ? "200" : "0"), 10),
+);
+```
+
+## 10. Tighten the middleware matcher
+
+Middleware that runs on API routes, static assets, and favicon requests burns Edge Request CPU
+Duration for nothing.
+
+```ts
+export const config = {
+	matcher: ["/((?!api/|api$|checkout/|checkout$|_next/|.*\\.[\\w]+$).*)"],
+};
+```
+
+The trailing `.*\\.[\\w]+$` excludes anything with a file extension. Note that self-hosted and
+`next start` deployments apply matchers differently, so keep any hard guards inside the middleware
+body too.
+
+## 11. Stop prefetching every link
+
+`prefetch={true}` on a grid of category tiles fires one RSC request per tile on viewport entry —
+edge requests, function invocations, and render time for pages most visitors never open. Leave
+Next's default (prefetch on hover) except on the one or two links you know convert.
+
+## 12. Check for duplicate webhook subscriptions
+
+If you run direct Saleor webhooks **and** a storefront app that subscribes to the same events, both
+deliver, and you pay for every invalidation twice. This is invisible in aggregate metrics.
+
+Log a short fingerprint of each delivery body. The same fingerprint arriving twice within seconds
+is a duplicate subscription, not two edits:
+
+```ts
+createHash("sha1").update(rawBody).digest("hex").slice(0, 12);
+```
+
+Do not use this to _drop_ deliveries — functions are multi-instance, so dedup here would be
+unreliable in exactly the way that silently loses invalidations.
+
+---
+
+## Verifying it worked
+
+Build, then list every source still reaching the optimizer:
+
+```bash
+pnpm build
+
+grep -rhoE '<img[^>]*data-nimg[^>]*>' .next/server/app --include='*.html' \
+  | grep -oE '/_next/image\?url=[^&"]+' \
+  | sed 's|.*url=||' \
+  | python3 -c 'import sys,urllib.parse as u;print("\n".join(sorted({u.unquote(l.strip()) for l in sys.stdin})))'
+```
+
+Filtering on `data-nimg` matters. A plain `grep` for `/_next/image` also matches the RSC flight
+payload embedded in `<script>` tags, which inflates the count with entries that never become
+requests. `data-nimg` is emitted only on elements `next/image` actually rendered.
+
+Expect a short list, and read it carefully — **every line is a component still on the optimizer.**
+On Paper's own build exactly one source survives: the homepage hero, which renders a raw CMS upload
+rather than a `thumbnail()` field and so has no rung set to request.
+
+Then compare a full billing cycle before and after on four meters in the Vercel dashboard: Image
+Optimization transformations, ISR writes, Active CPU, and Fast Data Transfer. The one to watch in
+week one is transformations. If the count does not collapse, something is still routing catalog
+images through the optimizer.
+
+### The silent fallback trap
+
+Item 5 only takes effect where a rung set actually reaches the component. Two patterns quietly keep
+paying, and neither produces a warning. This is not hypothetical — the first pass of this work
+converted the product grid and the PDP gallery and still left three sections on the optimizer:
+
+- **A section prop typed as a bare URL string.** `image-with-text`, `editorial-hero`, and
+  `category-tile-grid` all took `image?: string | null`, with nowhere to put a rung set. Saleor
+  images routed through them stayed on the optimizer even while the same product rendered as a raw
+  `<img srcset>` in the grid directly above. Each needs a parallel `imageSrcSet?: string` prop
+  threaded down from the page that owns the query.
+- **A field selected at exactly one size.** `backgroundImage(size: 1024, format: WEBP)` yields a
+  single candidate, `buildSaleorSrcSet` correctly returns `undefined`, and the component falls
+  back. Correct behaviour, but on a category tile grid it means every tile is billed. Add the
+  sibling aliases.
+
+Audit by grepping for the import, not by reading call sites:
+
+```bash
+grep -rl 'from "next/image"' src/ui/
+```
+
+For anything Saleor-backed on that list, either add the extra aliased rungs and switch to the
+`<img srcset>` path, or accept the cost deliberately. Where the fallback is intentional — a fixed
+80px cart thumbnail is not worth three rungs — leave a comment saying so, or someone will
+re-litigate it later.
+
+Where a component's props make the fallback invisible, make the rung fields **required** in the
+TypeScript type rather than optional. A dropped GraphQL alias then fails `tsc` instead of silently
+moving spend back onto the optimizer.
+
+## What this does not fix
+
+- **Thumbnail generation load on Saleor.** Item 5 moves work rather than removing it.
+- **Cold-start cost on genuinely dynamic routes.** Cart, checkout, and account pages have to render.
+- **Staleness when webhooks are not configured.** Item 7 widens the window from 60 seconds to an
+  hour. If you have no webhooks, keep the backstop tight and accept the cost.

--- a/docs/vercel-cost-optimization.md
+++ b/docs/vercel-cost-optimization.md
@@ -190,11 +190,11 @@ anything absent is logged and skipped. Then split events by whether they can cha
 // Changes a card: bust the listing tag.
 product_created, product_updated, product_deleted,
 product_media_created / _updated / _deleted,
+product_variant_created / _updated / _deleted,
 product_variant_discounted_price_updated
 
-// Cannot change a card, and fires orders of magnitude more often: PDP tag only.
-product_metadata_updated,
-product_variant_created / _updated / _deleted / _metadata_updated,
+// Cannot change a card, and fires far more often: PDP tag only.
+product_metadata_updated, product_variant_metadata_updated,
 product_variant_out_of_stock, product_variant_back_in_stock,
 product_variant_stock_updated, *_in_channel, *_for_click_and_collect
 ```
@@ -207,8 +207,9 @@ Event names are verifiable against `saleor/webhook/event_types.py` (`WebhookEven
 ## 7. Raise the catalog revalidate backstop
 
 If webhooks are wired up they are your freshness mechanism, and `revalidate` is only the safety net
-for a webhook that was never configured or got dropped. A 60-second backstop means a cached entry
-regenerates up to 1,440 times a day regardless of traffic.
+for a webhook that was never configured or got dropped. Regeneration is request-triggered — a cold
+entry costs nothing. A _hot_ entry with a 60-second backstop can approach 1,440 regenerations a
+day; an hour caps that at 24.
 
 ```js
 catalog: {

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,52 @@ const allowedDevOrigins = process.env.ALLOWED_DEV_ORIGINS?.split(",")
 	.map((origin) => origin.trim())
 	.filter(Boolean);
 
+const isDevelopment = process.env.NODE_ENV === "development";
+
+/** Host of the configured Saleor instance — self-hosted deploys serve media from it. */
+function saleorApiHostname() {
+	try {
+		return new URL(process.env.NEXT_PUBLIC_SALEOR_API_URL ?? "").hostname || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * `/_next/image` will optimize (and bill for) any host it is allowed to fetch, so an open
+ * `hostname: "*"` lets a third party turn the storefront into a free image CDN. Production
+ * gets an explicit allowlist; the wildcard stays in development only.
+ *
+ * Add non-Saleor sources (a DAM, a CMS) via IMAGE_ALLOWED_HOSTS. Not `NEXT_PUBLIC_` —
+ * it is read here at build time and must never be inlined into a client bundle.
+ */
+const imageRemotePatterns = [
+	{ hostname: "*.saleor.cloud" },
+	{ hostname: "*.media.saleor.cloud" },
+	...[saleorApiHostname()].filter(Boolean).map((hostname) => ({ hostname })),
+	...(process.env.IMAGE_ALLOWED_HOSTS?.split(",")
+		.map((host) => host.trim())
+		.filter(Boolean)
+		.map((hostname) => ({ hostname })) ?? []),
+	...(isDevelopment ? [{ hostname: "*" }] : []),
+];
+
+const THIRTY_ONE_DAYS_IN_SECONDS = 2678400;
+
+/** A typo here would otherwise become `NaN` and silently disable image caching. */
+function imageMinimumCacheTTLFromEnv() {
+	const raw = process.env.NEXT_IMAGE_MIN_CACHE_TTL;
+	if (!raw) return THIRTY_ONE_DAYS_IN_SECONDS;
+
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		throw new Error(`NEXT_IMAGE_MIN_CACHE_TTL must be a non-negative number of seconds, got "${raw}"`);
+	}
+	return parsed;
+}
+
+const imageMinimumCacheTTL = imageMinimumCacheTTLFromEnv();
+
 const config = {
 	...(allowedDevOrigins?.length ? { allowedDevOrigins } : {}),
 	// Cache Components (Partial Prerendering)
@@ -26,25 +72,28 @@ const config = {
 	experimental: {
 		optimizePackageImports: ["lucide-react", "lodash-es"],
 		// Note: API rate limiting is handled by RequestQueue in src/lib/graphql.ts
-		// (max 3 concurrent requests + 200ms delay between requests)
+		// (max 3 concurrent requests; the inter-request delay applies at build time only)
 	},
 	images: {
 		// WebP only: AVIF cold-encodes add ~500ms+ to first /_next/image hit on Vercel (hurts LCP).
 		formats: ["image/webp"],
-		remotePatterns: [
-			{
-				// Saleor Cloud CDN
-				hostname: "*.saleor.cloud",
-			},
-			{
-				// Saleor Media (common pattern)
-				hostname: "*.media.saleor.cloud",
-			},
-			{
-				// Allow all hostnames in development (restrict in production)
-				hostname: "*",
-			},
-		],
+		remotePatterns: imageRemotePatterns,
+
+		// Vercel bills image *transformations* and image *cache writes*. The default 4h TTL
+		// re-optimizes the same catalog image ~180x/month; Saleor thumbnail URLs are stable
+		// per (media id, size, format), so a long TTL is safe for the common case.
+		//
+		// Caveat: replacing an image *in place* in Saleor reuses the URL, so the old bytes
+		// are served until this expires. Brands that re-shoot frequently should lower
+		// NEXT_IMAGE_MIN_CACHE_TTL; uploading as new media always dodges it.
+		minimumCacheTTL: imageMinimumCacheTTL,
+
+		// Each width in these ladders is a separately billed transformation per source image.
+		// Trimmed from the Next defaults: 2048/3840 only serve 4K/retina-desktop (rare, and
+		// the widest variants are the most expensive to generate and store), and the tiny
+		// 16/32/48 steps are below anything Paper actually renders.
+		deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+		imageSizes: [64, 96, 128, 256, 384],
 	},
 	typedRoutes: false,
 
@@ -58,7 +107,7 @@ const config = {
 
 	// Cache headers for static assets and API routes
 	async headers() {
-		const isDev = process.env.NODE_ENV === "development";
+		const isDev = isDevelopment;
 		return [
 			// In development, prevent aggressive caching of dynamic chunks
 			...(isDev
@@ -95,12 +144,13 @@ const config = {
 				],
 			},
 			{
-				// OG Image API - cache for 1 day
+				// OG Image API — output is a pure function of the query string, and each render
+				// is expensive, so cache hard. Social crawlers refetch aggressively.
 				source: "/api/og",
 				headers: [
 					{
 						key: "Cache-Control",
-						value: "public, max-age=86400, stale-while-revalidate=604800",
+						value: "public, max-age=2592000, stale-while-revalidate=604800",
 					},
 				],
 			},

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -3465,7 +3465,34 @@ Both are stable per `(media id, size, format)`.
 
 **The consequence:** you cannot rewrite a Saleor image URL to change its width. The two URL shapes are not interchangeable, and rewriting a direct storage URL produces a 404. Any "custom loader that swaps the size segment" idea dies here — verify against `saleor/thumbnail/utils.py` (`get_image_or_proxy_url`) before trying it.
 
-So Paper asks Saleor for a sensibly-sized thumbnail, then lets `/_next/image` handle responsive widths from that already-small source.
+Saleor Cloud fronts those storage URLs with CloudFront at `cache-control: max-age=604800`. So for catalog images Paper skips `/_next/image` altogether: it asks Saleor for **several rungs at once** and hands the browser a real `srcset`. The optimizer stays in the path only for sources Saleor never produced.
+
+---
+
+## The two pipelines
+
+`NEXT_PUBLIC_PAPER_IMAGE_PIPELINE` (default `saleor`) selects between them; `vercel` is the escape hatch if your Saleor deployment has no CDN in front of media.
+
+|                        | Saleor-native `srcset`                                       | `next/image`                                                                              |
+| ---------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Use for                | Product cards, PDP gallery — anything with a Saleor rung set | CMS uploads, local assets, category backgrounds, slots far smaller than the smallest rung |
+| Transformations billed | none                                                         | one per `(src, width, quality)`                                                           |
+| Served by              | Saleor's CDN                                                 | `/_next/image`                                                                            |
+| Width selection        | browser, from the rungs you requested                        | optimizer, from `deviceSizes`                                                             |
+
+The rung sets live in [`images.ts`](../../../src/lib/images.ts) (`CATALOG_CARD_RUNGS`, `PDP_GALLERY_RUNGS`) and must match the aliased GraphQL fields:
+
+```graphql
+thumbnail(size: 1024, format: WEBP) { url alt }
+thumbnail256: thumbnail(size: 256, format: WEBP) { url }
+thumbnail512: thumbnail(size: 512, format: WEBP) { url }
+```
+
+Feed those to `buildSaleorSrcSet()` in the mapper, pass the result to [`<SaleorImage>`](../../../src/ui/atoms/saleor-image.tsx), and it renders a plain `<img srcset sizes>`. With no `srcSet` it falls back to `next/image`, so a surface Saleor can't serve degrades on its own rather than breaking.
+
+Two costs to accept: each aliased rung materialises its own `Thumbnail` row on Saleor (one-time generation), and the `<img>` path has to ask for the LCP preload that `next/image` emits for `priority` — `<SaleorImage>` does this via `ReactDOM.preload`.
+
+Prefer `next/image` when the slot is far smaller than the smallest rung you request. The PDP thumbnail strip is 80px against a 512 floor, so letting the browser pick a rung would ship ~6× the bytes to save two cheap transformations — the wrong trade.
 
 ---
 
@@ -3517,6 +3544,23 @@ Fixed-size images (`width`/`height`) are self-bounding and don't need `sizes` �
 
 `quality` is pinned at `PRODUCT_IMAGE_QUALITY` (75). Next 16 defaults `images.qualities` to `[75]`, so any other value is silently coerced unless you widen the allowlist — and each distinct quality multiplies the transformation count.
 
+A `sizes` constant describes a **layout**, not a surface. `PLP_HERO_IMAGE_SIZES` is `100vw` because a hero is genuinely edge-to-edge; reusing it on a `lg:grid-cols-2` panel asks for double the pixels that surface ever displays. Match the constant to the column width, or add one.
+
+---
+
+## Every `thumbnail` selection needs `size:` and `format:`
+
+A bare `thumbnail { url }` is not "the default, which is fine". Saleor's `resolve_thumbnail` defaults to **256px in the image's original format** — so a PNG product shot arrives as a PNG, and Vercel is then billed to transcode it to WebP on every distinct width. Passing `format: WEBP` moves that conversion to Saleor, where it is free and cached.
+
+```graphql
+thumbnail(size: 256, format: WEBP) {
+	url
+	alt
+}
+```
+
+Pick `size:` from the ladder at or just above the largest rendered slot in **device** pixels — the CSS box times the retina factor. A 128px slot on a 2× screen needs 256, not 128.
+
 ---
 
 ## Anti-patterns
@@ -3528,6 +3572,10 @@ Fixed-size images (`width`/`height`) are self-bounding and don't need `sizes` �
 ❌ Per-call-site `quality` values — each one is a separate transformation of the same image
 ❌ Widening `deviceSizes` "just in case" — every entry is a transformation per source image
 ❌ Requesting a huge Saleor `thumbnail(size:)` and letting Vercel shrink it — pay once, at the source
+❌ A bare `thumbnail { url }` — 256px in the original format, so Vercel pays for the WebP conversion
+❌ Off-ladder sizes in an aliased rung set — Saleor snaps to the nearest rung, so the `srcset` width descriptor lies about the pixels delivered
+❌ Routing a Saleor-backed catalog image through `next/image` when a rung set exists — that is the duplicated encode this rule exists to prevent
+❌ Reusing `PLP_HERO_IMAGE_SIZES` on anything that isn't full-bleed — a half-width panel wants `SPLIT_PANEL_IMAGE_SIZES`
 
 ---
 

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -294,7 +294,7 @@ Always use `applyCacheProfile(CACHE_PROFILES.*, slugOrChannel)` — **never** ra
 Slug-scoped catalog entries carry **two** tags: the entity tag (`product:{slug}`) and the profile `sharedTag` (`products`). Entity webhooks bust the precise tag; `?all=1` revalidates shared tags so the whole catalog clears without enumerating slugs.
 Named `cacheLife` tiers (configured in `next.config.js`): `catalog` (products/categories/collections/listings/CMS pages) is `stale 5 min / revalidate 1 hr / expire 1 day`, `menus` ~1 hr (nav/footer) and ~5 min (storefront-content), `channels` longer.
 
-`revalidate` is a **backstop**, not the freshness mechanism — webhooks are. A short backstop regenerates every entry on a timer whether or not anything changed, which is pure cost; only shorten it if a deployment genuinely cannot run webhooks.
+`revalidate` is a **backstop**, not the freshness mechanism — webhooks are. Regeneration is request-triggered: a cold entry costs nothing. A short backstop on a _hot_ entry can approach one regeneration per window (1,440/day at 60s); only shorten it if a deployment genuinely cannot run webhooks.
 
 ### Listing grids
 
@@ -372,15 +372,15 @@ Saleor event → saleor-paper-app → POST /api/revalidate → revalidateTag (+ 
 
 **The `saleor-event` header drives the scope.** `src/lib/webhook-events.ts` maps each event Paper acts on to an entity and an `affectsListing` flag; anything absent from that map is logged and skipped. Opting a new event into invalidation means adding it there. Never reintroduce a catch-all fallback — an unmapped event (orders, checkouts, customers) firing a catalog purge is a self-inflicted cost and cache-hit-rate problem.
 
-| Event family                                     | Storefront effect                                                                      |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `PRODUCT_*` / `PRODUCT_MEDIA_*` (card-affecting) | `product:{slug}` + `product-listing:{channel}`                                         |
-| `PRODUCT_VARIANT_*` stock/metadata               | `product:{slug}` only — never the listing tag                                          |
-| `CATEGORY_*`, `COLLECTION_*`                     | `category:{slug}` / `collection:{slug}` + `product-listing:{channel}`                  |
-| `PAGE_*`                                         | `page:{slug}`, and `storefront-content:{channel}:{locale}` when slug is `storefront-*` |
-| `MENU_*`, `MENU_ITEM_*`                          | `navigation:{channel}`, `footer-menu:{channel}`                                        |
-| `CHANNEL_*`                                      | `channels`                                                                             |
-| Everything else                                  | Logged and skipped                                                                     |
+| Event family                                                        | Storefront effect                                                                      |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `PRODUCT_*` / `PRODUCT_MEDIA_*` / variant created, updated, deleted | `product:{slug}` + `product-listing:{channel}`                                         |
+| `PRODUCT_VARIANT_*` stock / metadata                                | `product:{slug}` only — never the listing tag                                          |
+| `CATEGORY_*`, `COLLECTION_*`                                        | `category:{slug}` / `collection:{slug}` + `product-listing:{channel}`                  |
+| `PAGE_*`                                                            | `page:{slug}`, and `storefront-content:{channel}:{locale}` when slug is `storefront-*` |
+| `MENU_*`, `MENU_ITEM_*`                                             | `navigation:{channel}`, `footer-menu:{channel}`                                        |
+| `CHANNEL_*`                                                         | `channels`                                                                             |
+| Everything else                                                     | Logged and skipped                                                                     |
 
 Catalog entries are **tag-addressable** — `applyCacheProfile` attaches the entity tag inside every `"use cache"` function, so `revalidateTag` alone busts every locale. Per-locale `revalidatePath` fan-out is therefore redundant for catalog data and is only used for CMS pages. `revalidateTag` takes the manifest profile (`resolveRevalidateCacheLifeProfile("products")`).
 
@@ -415,7 +415,7 @@ Paper runs on Vercel, where the meters that matter are **function invocations + 
 
 | Knob                                                   | Default        | Raises cost when…                     | Trade-off when tightened                         |
 | ------------------------------------------------------ | -------------- | ------------------------------------- | ------------------------------------------------ |
-| `catalog.revalidate` (`cache-life-profiles.data.mjs`)  | 1 hr           | Lowered — timer-driven regeneration   | Staler catalog if webhooks are not configured    |
+| `catalog.revalidate` (`cache-life-profiles.data.mjs`)  | 1 hr           | Lowered — request-triggered backstop  | Staler catalog if webhooks are not configured    |
 | `isCacheableListingView()` allowlist                   | first page     | Widened — one entry per permutation   | Filtered views stay uncached (a live fetch each) |
 | `NEXT_IMAGE_MIN_CACHE_TTL`                             | 31 days        | Lowered — re-optimizes the same image | In-place image replacements are served stale     |
 | `images.deviceSizes` / `imageSizes` (`next.config.js`) | trimmed ladder | Widened — a transformation per width  | No >1920px variants for 4K displays              |

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -5,7 +5,7 @@ Saleor Paper
 June 2026
 
 > ⚠️ **Generated artifact — do not load this file in an agent session.** It concatenates
-> all 31 rules (~75k tokens) and exists only for humans reading offline and for
+> all 32 rules (~75k tokens) and exists only for humans reading offline and for
 > single-file skill export. **Agents:** read `SKILL.md`, then the **one** `rules/<task>.md`
 > whose frontmatter `description` matches the task. Never read this compiled file to "get oriented".
 >
@@ -16,7 +16,7 @@ June 2026
 
 ## Abstract
 
-Comprehensive guide for AI agents and LLMs maintaining the Saleor Paper storefront — a Next.js 16 e-commerce application with TypeScript, Tailwind CSS, and the Saleor GraphQL API. Covers 31 rules across 8 categories: architecture (canonical Next.js), data layer (caching, auth, GraphQL), product pages (PDP, variants, high-cardinality, filtering), checkout flow (surfaces, management, payments, components), design & composition (token system, design quality, section catalog, page composition, design-from-image, verification), UI & i18n, SEO, and development practices. Each rule includes architecture diagrams, code examples, file locations, and anti-patterns.
+Comprehensive guide for AI agents and LLMs maintaining the Saleor Paper storefront — a Next.js 16 e-commerce application with TypeScript, Tailwind CSS, and the Saleor GraphQL API. Covers 32 rules across 8 categories: architecture (canonical Next.js), data layer (caching, auth, GraphQL), product pages (PDP, variants, high-cardinality, filtering), checkout flow (surfaces, management, payments, components), design & composition (token system, design quality, section catalog, page composition, design-from-image, verification), UI & i18n, SEO, and development practices. Each rule includes architecture diagrams, code examples, file locations, and anti-patterns.
 
 ---
 
@@ -57,9 +57,10 @@ Comprehensive guide for AI agents and LLMs maintaining the Saleor Paper storefro
 
 5. [UI & Channels](#5-ui-channels) — **MEDIUM**
    - 5.1 [UI Components](#51-ui-components)
-   - 5.2 [Channels & Multi-Currency](#52-channels-multi-currency)
-   - 5.3 [Locale & Channel URL Routing](#53-locale-channel-url-routing)
-   - 5.4 [next-intl (Code-Owned UI Strings)](#54-next-intl-code-owned-ui-strings)
+   - 5.2 [Images](#52-images)
+   - 5.3 [Channels & Multi-Currency](#53-channels-multi-currency)
+   - 5.4 [Locale & Channel URL Routing](#54-locale-channel-url-routing)
+   - 5.5 [next-intl (Code-Owned UI Strings)](#55-next-intl-code-owned-ui-strings)
 
 6. [SEO](#6-seo) — **MEDIUM**
    - 6.1 [SEO & Metadata](#61-seo-metadata)
@@ -243,7 +244,9 @@ This rule holds **Paper's caching decisions** — what we cache, the contracts t
 
 | Surface                                | Data source                                                         | Freshness                              |
 | -------------------------------------- | ------------------------------------------------------------------- | -------------------------------------- |
-| PDP / category / collection / homepage | `getProductData()`, `getCategoryData()`, `getFeaturedProducts()`, … | Cached (~5 min)                        |
+| PDP / category / collection / homepage | `getProductData()`, `getCategoryData()`, `getFeaturedProducts()`, … | Webhook-invalidated (1 hr backstop)    |
+| Listing grids (unfiltered first page)  | `getProductListingPage()` and siblings                              | Webhook-invalidated (1 hr backstop)    |
+| Filtered / paginated listing views     | inline `executePublicGraphQL`                                       | **Always fresh** (uncached long tail)  |
 | Navigation / footer menus              | `getNavbarMenuItems()` / `getFooterMenuItems()`                     | Cached (~1 hr)                         |
 | Cart drawer, checkout, add-to-cart     | `Checkout.find()`, server actions, Saleor mutations                 | **Always fresh** (`cache: "no-cache"`) |
 
@@ -282,13 +285,20 @@ Always use `applyCacheProfile(CACHE_PROFILES.*, slugOrChannel)` — **never** ra
 | `collection:{slug}`                                 | `collections`        | `getCollectionData()`, `getFeaturedProducts()`            | Collection updated                |
 | `page:{slug}`                                       | `pages`              | `getPageData()` (CMS)                                     | Page updated                      |
 | `products` / `categories` / `collections` / `pages` | same (sharedTag)     | Applied alongside each entity tag via `applyCacheProfile` | Full purge (`?all=1`), promotions |
+| `product-listing:{channel}`                         | `productListing`     | `getProductListingPage()` / category / collection grids   | Product event that changes a card |
 | `navigation:{channel}`                              | `navigation`         | `getNavbarMenuItems()`                                    | Navbar changed                    |
 | `footer-menu:{channel}`                             | `footerMenu`         | `getFooterMenuItems()`                                    | Footer changed                    |
 | `storefront-content:{channel}:{locale}`             | `storefront-content` | `getStorefrontContent()`                                  | `storefront-*` Page updated       |
 | `channels`                                          | `channels`           | `getCachedChannelsList()`                                 | Channel list changed              |
 
 Slug-scoped catalog entries carry **two** tags: the entity tag (`product:{slug}`) and the profile `sharedTag` (`products`). Entity webhooks bust the precise tag; `?all=1` revalidates shared tags so the whole catalog clears without enumerating slugs.
-Named `cacheLife` tiers (configured in `next.config.js`): `catalog` ~5 min (products/categories/collections/CMS pages), `menus` ~1 hr (nav/footer) and ~5 min (storefront-content), `channels` longer.
+Named `cacheLife` tiers (configured in `next.config.js`): `catalog` (products/categories/collections/listings/CMS pages) is `stale 5 min / revalidate 1 hr / expire 1 day`, `menus` ~1 hr (nav/footer) and ~5 min (storefront-content), `channels` longer.
+
+`revalidate` is a **backstop**, not the freshness mechanism — webhooks are. A short backstop regenerates every entry on a timer whether or not anything changed, which is pure cost; only shorten it if a deployment genuinely cannot run webhooks.
+
+### Listing grids
+
+Listing grids are cached only for the **unfiltered first page** (any sort order) — see `isCacheableListingView()` in `src/lib/catalog/get-product-listing.ts`. Filtered and paginated views fall through to a live fetch on purpose: every filter permutation would be a cache entry that is written once and rarely read again, trading invocation cost for cache-write cost. Entry count stays bounded by `sorts × locales × channels`, independent of catalog size.
 
 `GET /api/cache-info` returns the machine-readable manifest (Bearer `REVALIDATE_SECRET`, timing-safe) so the saleor-paper-app can build its invalidation UI dynamically. Manifest **v6+** includes an optional `identity` block (`saleorApiUrl`, `environment`, deploy metadata) for the Paper handshake. `saleorApiUrl` comes from `NEXT_PUBLIC_SALEOR_API_URL`. `environment` defaults from `VERCEL_ENV` / `NODE_ENV`; set `PAPER_STOREFRONT_ENVIRONMENT` only when those lie (true staging, or non-Vercel hosts that aren't prod).
 
@@ -347,7 +357,7 @@ applyCacheProfile(CACHE_PROFILES.products, slug); // single tag product:hoodie c
 ```
 
 - Cached fetches pass `graphqlLanguageCodeVariables(localeSlug)`; map URL slugs to Saleor **base** codes in `src/config/locale.ts` (`pl` → `PL`, not `PL_PL`). Merge translations with `withTranslatedProductFields()` (`src/lib/saleor-translations.ts`) after the fetch.
-- **Invalidation fan-out:** catalog tags stay slug-scoped; `buildPathsForAllLocales()` revalidates every configured locale path on a generic `PRODUCT_UPDATED`.
+- **Invalidation fan-out:** catalog tags stay slug-scoped and locale-agnostic — one `revalidateTag("product:hoodie")` clears every locale entry, so no path fan-out is needed.
 - Adding locales adds ~N cache entries (one per locale × page), not per-request work. Each locale warms independently after deploy.
 
 ---
@@ -357,16 +367,24 @@ applyCacheProfile(CACHE_PROFILES.products, slug); // single tag product:hoodie c
 **Production path: [saleor-paper-app](https://github.com/saleor/saleor-paper-app).** On install it registers managed webhooks and proxies them to the storefront:
 
 ```
-Saleor event → saleor-paper-app → POST /api/revalidate → revalidateTag + revalidatePath
+Saleor event → saleor-paper-app → POST /api/revalidate → revalidateTag (+ revalidatePath for CMS pages)
 ```
 
-| Event family                              | Storefront effect                                                                      |
-| ----------------------------------------- | -------------------------------------------------------------------------------------- |
-| `PRODUCT_*`, `CATEGORY_*`, `COLLECTION_*` | Catalog tags + paths (all locales via `buildPathsForAllLocales`)                       |
-| `PAGE_*`                                  | `page:{slug}`, and `storefront-content:{channel}:{locale}` when slug is `storefront-*` |
-| `MENU_*`, `MENU_ITEM_*`                   | `navigation:{channel}`, `footer-menu:{channel}`                                        |
+**The `saleor-event` header drives the scope.** `src/lib/webhook-events.ts` maps each event Paper acts on to an entity and an `affectsListing` flag; anything absent from that map is logged and skipped. Opting a new event into invalidation means adding it there. Never reintroduce a catch-all fallback — an unmapped event (orders, checkouts, customers) firing a catalog purge is a self-inflicted cost and cache-hit-rate problem.
 
-`revalidateTag` takes the manifest profile (`resolveRevalidateCacheLifeProfile("products")`); paths use `getStorefrontChannelSlugs()` × `buildPathsForAllLocales()`. **Don't** point Saleor webhooks directly at `/api/revalidate` while the app is installed (duplicate deliveries, no logging). Direct webhooks remain valid for self-hosted setups without the app (set `SALEOR_WEBHOOK_SECRET`).
+| Event family                                     | Storefront effect                                                                      |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `PRODUCT_*` / `PRODUCT_MEDIA_*` (card-affecting) | `product:{slug}` + `product-listing:{channel}`                                         |
+| `PRODUCT_VARIANT_*` stock/metadata               | `product:{slug}` only — never the listing tag                                          |
+| `CATEGORY_*`, `COLLECTION_*`                     | `category:{slug}` / `collection:{slug}` + `product-listing:{channel}`                  |
+| `PAGE_*`                                         | `page:{slug}`, and `storefront-content:{channel}:{locale}` when slug is `storefront-*` |
+| `MENU_*`, `MENU_ITEM_*`                          | `navigation:{channel}`, `footer-menu:{channel}`                                        |
+| `CHANNEL_*`                                      | `channels`                                                                             |
+| Everything else                                  | Logged and skipped                                                                     |
+
+Catalog entries are **tag-addressable** — `applyCacheProfile` attaches the entity tag inside every `"use cache"` function, so `revalidateTag` alone busts every locale. Per-locale `revalidatePath` fan-out is therefore redundant for catalog data and is only used for CMS pages. `revalidateTag` takes the manifest profile (`resolveRevalidateCacheLifeProfile("products")`).
+
+**Don't** point Saleor webhooks directly at `/api/revalidate` while the app is installed (duplicate deliveries, doubled invalidation cost). Each delivery logs its `saleor-event` and `saleor-api-url`, so duplicates show up as two identical log lines per change — check there first if invalidation looks twice as busy as expected. Direct webhooks remain valid for self-hosted setups without the app (set `SALEOR_WEBHOOK_SECRET`).
 
 **Manual / emergency** (Bearer header, timing-safe; `?secret=` is deprecated):
 
@@ -380,7 +398,7 @@ curl -H "Authorization: Bearer <REVALIDATE_SECRET>" \
   "https://store.com/api/revalidate?all=1"
 ```
 
-Without webhooks, TTL takes over (catalog ~5 min, menus ~1 hr).
+Without webhooks, TTL takes over (catalog 1 hr, menus 1 hr).
 
 ### Debugging stale content
 
@@ -388,6 +406,27 @@ Without webhooks, TTL takes over (catalog ~5 min, menus ~1 hr).
 2. Tag exact? (`product:blue-hoodie` — slug must match).
 3. Force: `curl … "?tag=product:my-product"`.
 4. Translation still wrong language on `/pl/…`? Confirm a `PL` base translation exists; bust the tag; restart dev if you changed `src/config/locale.ts`.
+
+---
+
+## Cost controls
+
+Paper runs on Vercel, where the meters that matter are **function invocations + active CPU**, **edge middleware invocations**, **image transformations**, and **cache writes/bandwidth**. Caching decisions are cost decisions; these are the knobs, and each trades money against freshness.
+
+| Knob                                                   | Default        | Raises cost when…                     | Trade-off when tightened                         |
+| ------------------------------------------------------ | -------------- | ------------------------------------- | ------------------------------------------------ |
+| `catalog.revalidate` (`cache-life-profiles.data.mjs`)  | 1 hr           | Lowered — timer-driven regeneration   | Staler catalog if webhooks are not configured    |
+| `isCacheableListingView()` allowlist                   | first page     | Widened — one entry per permutation   | Filtered views stay uncached (a live fetch each) |
+| `NEXT_IMAGE_MIN_CACHE_TTL`                             | 31 days        | Lowered — re-optimizes the same image | In-place image replacements are served stale     |
+| `images.deviceSizes` / `imageSizes` (`next.config.js`) | trimmed ladder | Widened — a transformation per width  | No >1920px variants for 4K displays              |
+| `IMAGE_ALLOWED_HOSTS`                                  | unset          | Widened — third parties can bill you  | Non-Saleor image sources must be listed          |
+| `SALEOR_MIN_REQUEST_DELAY_MS`                          | 0 at runtime   | Raised — billed idle CPU per request  | Less protection against Saleor API rate limits   |
+
+Rules of thumb:
+
+- **A cache entry is only worth writing if it will be read again before it expires.** That is the whole argument for the listing allowlist, and the test to apply before caching anything new.
+- **Prefer webhook invalidation over short TTLs.** A TTL charges you continuously for freshness you need occasionally.
+- **Narrow the invalidation scope, not the cache.** Busting less on each event beats caching less.
 
 ---
 
@@ -399,6 +438,10 @@ Without webhooks, TTL takes over (catalog ~5 min, menus ~1 hr).
 ❌ Awaiting `searchParams` in a shell — collapses the route into a dynamic hole (move to an island)
 ❌ Raw `cacheLife("minutes")` / hand-rolled `cacheTag` — use `applyCacheProfile(CACHE_PROFILES.*)`
 ❌ Fetch-level `revalidate` inside `"use cache"` — `cacheLife` + webhooks own freshness
+❌ A catch-all `default:` in the webhook switch — unmapped events must log and skip, not purge
+❌ Busting listing tags on stock/metadata events — inventory sync would keep the grids permanently cold
+❌ Caching every filter/cursor permutation — unbounded cache writes for entries nobody re-reads
+❌ Shortening the `catalog` backstop to "make things fresher" — configure webhooks instead
 ❌ Wrapping only `<main>` in Suspense to silence a PPR error — fix the segment that owns the work
 ❌ Omitting `localeSlug` from cached fetches — all locales share one entry, wrong language
 ❌ Regional Saleor codes (`PL_PL`) in `graphqlLanguageCode` — Dashboard uses base codes (`PL`)
@@ -3400,7 +3443,105 @@ export function Card({ title, children, className }: CardProps) {
 
 ---
 
-### 5.2 Channels & Multi-Currency
+### 5.2 Images
+
+Images are usually the largest line on a Paper storefront's Vercel bill — transformations and image cache writes both scale with the size of the catalog times the number of widths requested. The decisions here are about **not paying twice for the same optimization**.
+
+---
+
+## The one decision: Saleor optimizes, Vercel resizes
+
+> **Saleor already returns a compressed, format-converted thumbnail. Vercel's optimizer should only be picking a width — never redoing the encode from a 4000px original.**
+
+Saleor's `thumbnail(size:, format:)` field does real work server-side:
+
+- It snaps the requested size to a fixed ladder — `[32, 64, 128, 256, 512, 1024, 2048, 4096]` — and picks the **nearest** entry, not the next one up. Asking for 300 gives you 256.
+- It converts format (`format: WEBP`) and caches the result.
+- The returned URL is one of two shapes, and **this is the part that catches people out**:
+  - a **direct storage URL** once the thumbnail has been generated, or
+  - a **proxy URL** (`/thumbnail/{id}/{size}/{format}/`) that generates on first hit and 302s to storage.
+
+Both are stable per `(media id, size, format)`.
+
+**The consequence:** you cannot rewrite a Saleor image URL to change its width. The two URL shapes are not interchangeable, and rewriting a direct storage URL produces a 404. Any "custom loader that swaps the size segment" idea dies here — verify against `saleor/thumbnail/utils.py` (`get_image_or_proxy_url`) before trying it.
+
+So Paper asks Saleor for a sensibly-sized thumbnail, then lets `/_next/image` handle responsive widths from that already-small source.
+
+---
+
+## Cost model
+
+Vercel meters images two ways, and both are driven by **how many distinct URLs you generate**, not how many requests you serve:
+
+| Meter              | Driven by                                               |
+| ------------------ | ------------------------------------------------------- |
+| Transformations    | unique `(src, width, quality, format)` — first hit only |
+| Image cache writes | each transformation's result being stored               |
+
+Every entry in `deviceSizes`/`imageSizes` that a `sizes` attribute can select is a potential transformation **per source image**. A 5,000-product catalog with 8 candidate widths is 40,000 transformations before anyone visits a second page.
+
+That leads to three levers, all in [`next.config.js`](../../../next.config.js):
+
+1. **`minimumCacheTTL`** (Paper: 31 days, override with `NEXT_IMAGE_MIN_CACHE_TTL`). The Next default is 4 hours, which re-optimizes the same unchanged catalog image ~180×/month. Saleor URLs are stable, so a long TTL is nearly free correctness-wise — **except** that replacing an image in place in Saleor reuses the URL, so the old bytes serve until expiry. Uploading as new media always dodges this.
+2. **`deviceSizes` / `imageSizes`** — trimmed below the Next defaults. The 2048/3840 steps only serve 4K displays and are the most expensive to generate and store; the 16/32/48 steps are smaller than anything Paper renders.
+3. **`formats: ["image/webp"]`** — WebP only. AVIF compresses better but cold-encodes add ~500ms+ to the first `/_next/image` hit, which lands directly on LCP.
+
+---
+
+## `remotePatterns` is a security control, not just config
+
+`/_next/image` will fetch and optimize **any** host it is allowed to, and you are billed for it. A wildcard `hostname: "*"` in production lets anyone use the storefront as a free image CDN by hitting `/_next/image?url=…`.
+
+Paper builds the production allowlist from Saleor Cloud hosts plus the configured `NEXT_PUBLIC_SALEOR_API_URL` host, with extra sources (a DAM, a CMS) added via `IMAGE_ALLOWED_HOSTS`. The wildcard is **development-only**.
+
+---
+
+## Every `fill` image needs `sizes`
+
+Without `sizes`, Next assumes `100vw` and requests the widest candidate in `deviceSizes` — so an 80px cart thumbnail downloads a 1920px image. This is the single most common image bug and it is invisible locally, where everything is fast.
+
+Shared `sizes` strings live in [`src/lib/images.ts`](../../../src/lib/images.ts), keyed to the layout breakpoints they describe (`PLP_IMAGE_SIZES`, `PDP_MAIN_IMAGE_SIZES`, `CART_THUMBNAIL_IMAGE_SIZES`, …). Add a constant there rather than inlining a string, so the value stays reviewable next to the others.
+
+```tsx
+<Image
+	src={product.image}
+	alt={product.imageAlt || product.name}
+	fill
+	sizes={PLP_IMAGE_SIZES}
+	quality={PRODUCT_IMAGE_QUALITY}
+	className="object-cover"
+/>
+```
+
+Fixed-size images (`width`/`height`) are self-bounding and don't need `sizes` — Next requests roughly `width` and `width × 2`.
+
+`quality` is pinned at `PRODUCT_IMAGE_QUALITY` (75). Next 16 defaults `images.qualities` to `[75]`, so any other value is silently coerced unless you widen the allowlist — and each distinct quality multiplies the transformation count.
+
+---
+
+## Anti-patterns
+
+❌ `fill` without `sizes` — requests the widest variant for a thumbnail slot
+❌ `hostname: "*"` in `remotePatterns` for production — third parties bill you
+❌ A custom loader that rewrites Saleor thumbnail URL widths — the two URL shapes aren't interchangeable
+❌ Adding AVIF to `formats` — doubles transformations and cold-encode cost lands on LCP
+❌ Per-call-site `quality` values — each one is a separate transformation of the same image
+❌ Widening `deviceSizes` "just in case" — every entry is a transformation per source image
+❌ Requesting a huge Saleor `thumbnail(size:)` and letting Vercel shrink it — pay once, at the source
+
+---
+
+## Key files
+
+| File                              | Purpose                                                         |
+| --------------------------------- | --------------------------------------------------------------- |
+| `next.config.js` → `images`       | Allowlist, TTL, width ladders, formats                          |
+| `src/lib/images.ts`               | Shared `sizes` strings and quality constant                     |
+| `src/graphql/fragments/*.graphql` | `thumbnail(size:, format:)` selections — the source-side budget |
+
+---
+
+### 5.3 Channels & Multi-Currency
 
 Configure multi-channel and multi-currency support. This storefront supports multiple Saleor channels, each with its own currency. Understanding the underlying fulfillment model helps debug "product not purchasable" issues.
 
@@ -3571,7 +3712,7 @@ Default locale slug: `en` (`NEXT_PUBLIC_DEFAULT_LOCALE`). Configure `NEXT_PUBLIC
 
 ---
 
-### 5.3 Locale & Channel URL Routing
+### 5.4 Locale & Channel URL Routing
 
 Browse routes use **two URL prefixes**: locale (language) then channel (market). Checkout is unchanged.
 
@@ -3712,7 +3853,7 @@ Run **301** from old URLs for at least one release.
 
 ---
 
-### 5.4 next-intl (Code-Owned UI Strings)
+### 5.5 next-intl (Code-Owned UI Strings)
 
 Functional storefront strings — buttons, labels, validation, a11y, order status — live in **`messages/{locale}.json`**, not Saleor Models.
 

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -3490,7 +3490,13 @@ thumbnail512: thumbnail(size: 512, format: WEBP) { url }
 
 Feed those to `buildSaleorSrcSet()` in the mapper, pass the result to [`<SaleorImage>`](../../../src/ui/atoms/saleor-image.tsx), and it renders a plain `<img srcset sizes>`. With no `srcSet` it falls back to `next/image`, so a surface Saleor can't serve degrades on its own rather than breaking.
 
-Two costs to accept: each aliased rung materialises its own `Thumbnail` row on Saleor (one-time generation), and the `<img>` path has to ask for the LCP preload that `next/image` emits for `priority` — `<SaleorImage>` does this via `ReactDOM.preload`.
+Three consequences of leaving the optimizer, all handled but none of them free:
+
+- **Connection setup moves onto the critical path.** `/_next/image` is same-origin, so it reuses the document's connection; Saleor's CDN is a different origin and costs DNS + TCP + TLS before the LCP image's first byte. The storefront root layout emits a `<link rel="preconnect">` from `saleorMediaPreconnectOrigin()`. It carries no `crossOrigin`, because plain `<img>` fetches are not CORS and a mismatched hint warms a connection the load cannot reuse. The origin is derived from `NEXT_PUBLIC_SALEOR_API_URL`; a deployment serving media from a separate domain needs its own hint.
+- **`priority` no longer implies a preload.** `next/image` emits one; the `<img>` path asks for it explicitly via `ReactDOM.preload`.
+- **A rung you have never requested comes back as a proxy URL, and cached pages bake it in.** `resolve_thumbnail` returns `/thumbnail/{id}/{size}/{format}/` until a `Thumbnail` row exists, so right after adding a rung the prerendered payload is full of URLs that 302 to storage — one extra round trip per image, on the LCP path. It self-heals: the first hit generates the file, the next resolve returns the storage URL, and the next re-render embeds it. On a large catalogue, crawl the new rungs before cutting traffic over. Verify with `curl -sI` on a fresh rung; a `302` means it has not been materialised yet.
+
+Type the rung fields as **required** where you consume them. If a fragment loses an alias, that should fail typecheck, not silently fall back to `/_next/image` and quietly start billing again.
 
 Prefer `next/image` when the slot is far smaller than the smallest rung you request. The PDP thumbnail strip is 80px against a 512 floor, so letting the browser pick a rung would ship ~6× the bytes to save two cheap transformations — the wrong trade.
 

--- a/skills/saleor-paper-storefront/AGENTS.md
+++ b/skills/saleor-paper-storefront/AGENTS.md
@@ -372,6 +372,8 @@ Saleor event → saleor-paper-app → POST /api/revalidate → revalidateTag (+ 
 
 **The `saleor-event` header drives the scope.** `src/lib/webhook-events.ts` maps each event Paper acts on to an entity and an `affectsListing` flag; anything absent from that map is logged and skipped. Opting a new event into invalidation means adding it there. Never reintroduce a catch-all fallback — an unmapped event (orders, checkouts, customers) firing a catalog purge is a self-inflicted cost and cache-hit-rate problem.
 
+saleor-paper-app forwards that header on every entity POST. A POST without it (manual curl, older app) is treated as listing-affecting. After upgrading the app, click **Sync Webhooks** so Saleor delivers variant CRUD, stock, and metadata — stock events must arrive _with_ `saleor-event` or they bust the listing tag. Do not also subscribe the app to `PRODUCT_MEDIA_*`; Saleor already emits `PRODUCT_UPDATED` for media edits.
+
 | Event family                                                        | Storefront effect                                                                      |
 | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | `PRODUCT_*` / `PRODUCT_MEDIA_*` / variant created, updated, deleted | `product:{slug}` + `product-listing:{channel}`                                         |

--- a/skills/saleor-paper-storefront/README.md
+++ b/skills/saleor-paper-storefront/README.md
@@ -34,15 +34,15 @@ npx skills add saleor/agent-skills --skill saleor-storefront
 
 31 rules across 8 categories covering the full storefront:
 
-| Category      | Rules                                                                                                                                                                           | Topics                                                            |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Architecture  | `paper-architecture`                                                                                                                                                            | Canonical Next.js stance, pillar index, deliberate non-goals      |
-| Data Layer    | `data-caching`, `data-auth-routes`, `data-redirect-security`, `data-graphql`, `data-storefront-content`, `data-storefront-content-saleor`, `data-storefront-content-attributes` | Cache, auth, GraphQL, merchandising copy, Models, attribute types |
-| Product Pages | `product-pdp`, `product-variants`, `product-high-cardinality`, `product-filtering`                                                                                              | PDP architecture, variant selection, high-cardinality caps/facets |
-| Checkout      | `paper-surfaces`, `checkout-design-principles`, `checkout-management`, `checkout-payment-gateways`, `checkout-components`                                                       | Checkout v2, UX principles, lifecycle, payments, UI               |
-| UI & Channels | `ui-components`, `ui-channels`, `ui-locale-routing`, `ui-i18n`                                                                                                                  | Design tokens, multi-currency, locale URLs, next-intl messages    |
-| SEO           | `seo-metadata`                                                                                                                                                                  | JSON-LD, OG images, metadata                                      |
-| Development   | `dev-local`, `dev-investigation`                                                                                                                                                | Mobile/ngrok dev setup; Saleor API investigation                  |
+| Category      | Rules                                                                                                                                                                           | Topics                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Architecture  | `paper-architecture`                                                                                                                                                            | Canonical Next.js stance, pillar index, deliberate non-goals                      |
+| Data Layer    | `data-caching`, `data-auth-routes`, `data-redirect-security`, `data-graphql`, `data-storefront-content`, `data-storefront-content-saleor`, `data-storefront-content-attributes` | Cache, auth, GraphQL, merchandising copy, Models, attribute types                 |
+| Product Pages | `product-pdp`, `product-variants`, `product-high-cardinality`, `product-filtering`                                                                                              | PDP architecture, variant selection, high-cardinality caps/facets                 |
+| Checkout      | `paper-surfaces`, `checkout-design-principles`, `checkout-management`, `checkout-payment-gateways`, `checkout-components`                                                       | Checkout v2, UX principles, lifecycle, payments, UI                               |
+| UI & Channels | `ui-components`, `ui-images`, `ui-channels`, `ui-locale-routing`, `ui-i18n`                                                                                                     | Design tokens, image cost budget, multi-currency, locale URLs, next-intl messages |
+| SEO           | `seo-metadata`                                                                                                                                                                  | JSON-LD, OG images, metadata                                                      |
+| Development   | `dev-local`, `dev-investigation`                                                                                                                                                | Mobile/ngrok dev setup; Saleor API investigation                                  |
 
 ## Structure
 
@@ -67,6 +67,7 @@ saleor-paper-storefront/
 │   ├── checkout-payment-gateways.md
 │   ├── checkout-components.md
 │   ├── ui-components.md
+│   ├── ui-images.md
 │   ├── ui-channels.md
 │   ├── seo-metadata.md
 │   ├── dev-local.md

--- a/skills/saleor-paper-storefront/SKILL.md
+++ b/skills/saleor-paper-storefront/SKILL.md
@@ -104,6 +104,7 @@ Reference these guidelines when:
 
 - `references/code-conventions.md` - kebab-case files, PascalCase exports, `@/` imports
 - `ui-components` - Design tokens, shadcn/ui primitives, component locations
+- `ui-images` - Saleor thumbnails vs Vercel's optimizer, `sizes` discipline, image cost budget
 - `ui-channels` - Channel allowlist, fulfillment triangle, multi-currency, channel selector
 - `ui-locale-routing` - `/{locale}/{channel}/` routing, middleware redirects, path helpers
 - `ui-i18n` - next-intl namespaces, server/client patterns, ADR 0002 boundary

--- a/skills/saleor-paper-storefront/rules/data-caching.md
+++ b/skills/saleor-paper-storefront/rules/data-caching.md
@@ -22,7 +22,9 @@ This rule holds **Paper's caching decisions** — what we cache, the contracts t
 
 | Surface                                | Data source                                                         | Freshness                              |
 | -------------------------------------- | ------------------------------------------------------------------- | -------------------------------------- |
-| PDP / category / collection / homepage | `getProductData()`, `getCategoryData()`, `getFeaturedProducts()`, … | Cached (~5 min)                        |
+| PDP / category / collection / homepage | `getProductData()`, `getCategoryData()`, `getFeaturedProducts()`, … | Webhook-invalidated (1 hr backstop)    |
+| Listing grids (unfiltered first page)  | `getProductListingPage()` and siblings                              | Webhook-invalidated (1 hr backstop)    |
+| Filtered / paginated listing views     | inline `executePublicGraphQL`                                       | **Always fresh** (uncached long tail)  |
 | Navigation / footer menus              | `getNavbarMenuItems()` / `getFooterMenuItems()`                     | Cached (~1 hr)                         |
 | Cart drawer, checkout, add-to-cart     | `Checkout.find()`, server actions, Saleor mutations                 | **Always fresh** (`cache: "no-cache"`) |
 
@@ -61,13 +63,20 @@ Always use `applyCacheProfile(CACHE_PROFILES.*, slugOrChannel)` — **never** ra
 | `collection:{slug}`                                 | `collections`        | `getCollectionData()`, `getFeaturedProducts()`            | Collection updated                |
 | `page:{slug}`                                       | `pages`              | `getPageData()` (CMS)                                     | Page updated                      |
 | `products` / `categories` / `collections` / `pages` | same (sharedTag)     | Applied alongside each entity tag via `applyCacheProfile` | Full purge (`?all=1`), promotions |
+| `product-listing:{channel}`                         | `productListing`     | `getProductListingPage()` / category / collection grids   | Product event that changes a card |
 | `navigation:{channel}`                              | `navigation`         | `getNavbarMenuItems()`                                    | Navbar changed                    |
 | `footer-menu:{channel}`                             | `footerMenu`         | `getFooterMenuItems()`                                    | Footer changed                    |
 | `storefront-content:{channel}:{locale}`             | `storefront-content` | `getStorefrontContent()`                                  | `storefront-*` Page updated       |
 | `channels`                                          | `channels`           | `getCachedChannelsList()`                                 | Channel list changed              |
 
 Slug-scoped catalog entries carry **two** tags: the entity tag (`product:{slug}`) and the profile `sharedTag` (`products`). Entity webhooks bust the precise tag; `?all=1` revalidates shared tags so the whole catalog clears without enumerating slugs.
-Named `cacheLife` tiers (configured in `next.config.js`): `catalog` ~5 min (products/categories/collections/CMS pages), `menus` ~1 hr (nav/footer) and ~5 min (storefront-content), `channels` longer.
+Named `cacheLife` tiers (configured in `next.config.js`): `catalog` (products/categories/collections/listings/CMS pages) is `stale 5 min / revalidate 1 hr / expire 1 day`, `menus` ~1 hr (nav/footer) and ~5 min (storefront-content), `channels` longer.
+
+`revalidate` is a **backstop**, not the freshness mechanism — webhooks are. A short backstop regenerates every entry on a timer whether or not anything changed, which is pure cost; only shorten it if a deployment genuinely cannot run webhooks.
+
+### Listing grids
+
+Listing grids are cached only for the **unfiltered first page** (any sort order) — see `isCacheableListingView()` in `src/lib/catalog/get-product-listing.ts`. Filtered and paginated views fall through to a live fetch on purpose: every filter permutation would be a cache entry that is written once and rarely read again, trading invocation cost for cache-write cost. Entry count stays bounded by `sorts × locales × channels`, independent of catalog size.
 
 `GET /api/cache-info` returns the machine-readable manifest (Bearer `REVALIDATE_SECRET`, timing-safe) so the saleor-paper-app can build its invalidation UI dynamically. Manifest **v6+** includes an optional `identity` block (`saleorApiUrl`, `environment`, deploy metadata) for the Paper handshake. `saleorApiUrl` comes from `NEXT_PUBLIC_SALEOR_API_URL`. `environment` defaults from `VERCEL_ENV` / `NODE_ENV`; set `PAPER_STOREFRONT_ENVIRONMENT` only when those lie (true staging, or non-Vercel hosts that aren't prod).
 
@@ -126,7 +135,7 @@ applyCacheProfile(CACHE_PROFILES.products, slug); // single tag product:hoodie c
 ```
 
 - Cached fetches pass `graphqlLanguageCodeVariables(localeSlug)`; map URL slugs to Saleor **base** codes in `src/config/locale.ts` (`pl` → `PL`, not `PL_PL`). Merge translations with `withTranslatedProductFields()` (`src/lib/saleor-translations.ts`) after the fetch.
-- **Invalidation fan-out:** catalog tags stay slug-scoped; `buildPathsForAllLocales()` revalidates every configured locale path on a generic `PRODUCT_UPDATED`.
+- **Invalidation fan-out:** catalog tags stay slug-scoped and locale-agnostic — one `revalidateTag("product:hoodie")` clears every locale entry, so no path fan-out is needed.
 - Adding locales adds ~N cache entries (one per locale × page), not per-request work. Each locale warms independently after deploy.
 
 ---
@@ -136,16 +145,24 @@ applyCacheProfile(CACHE_PROFILES.products, slug); // single tag product:hoodie c
 **Production path: [saleor-paper-app](https://github.com/saleor/saleor-paper-app).** On install it registers managed webhooks and proxies them to the storefront:
 
 ```
-Saleor event → saleor-paper-app → POST /api/revalidate → revalidateTag + revalidatePath
+Saleor event → saleor-paper-app → POST /api/revalidate → revalidateTag (+ revalidatePath for CMS pages)
 ```
 
-| Event family                              | Storefront effect                                                                      |
-| ----------------------------------------- | -------------------------------------------------------------------------------------- |
-| `PRODUCT_*`, `CATEGORY_*`, `COLLECTION_*` | Catalog tags + paths (all locales via `buildPathsForAllLocales`)                       |
-| `PAGE_*`                                  | `page:{slug}`, and `storefront-content:{channel}:{locale}` when slug is `storefront-*` |
-| `MENU_*`, `MENU_ITEM_*`                   | `navigation:{channel}`, `footer-menu:{channel}`                                        |
+**The `saleor-event` header drives the scope.** `src/lib/webhook-events.ts` maps each event Paper acts on to an entity and an `affectsListing` flag; anything absent from that map is logged and skipped. Opting a new event into invalidation means adding it there. Never reintroduce a catch-all fallback — an unmapped event (orders, checkouts, customers) firing a catalog purge is a self-inflicted cost and cache-hit-rate problem.
 
-`revalidateTag` takes the manifest profile (`resolveRevalidateCacheLifeProfile("products")`); paths use `getStorefrontChannelSlugs()` × `buildPathsForAllLocales()`. **Don't** point Saleor webhooks directly at `/api/revalidate` while the app is installed (duplicate deliveries, no logging). Direct webhooks remain valid for self-hosted setups without the app (set `SALEOR_WEBHOOK_SECRET`).
+| Event family                                     | Storefront effect                                                                      |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `PRODUCT_*` / `PRODUCT_MEDIA_*` (card-affecting) | `product:{slug}` + `product-listing:{channel}`                                         |
+| `PRODUCT_VARIANT_*` stock/metadata               | `product:{slug}` only — never the listing tag                                          |
+| `CATEGORY_*`, `COLLECTION_*`                     | `category:{slug}` / `collection:{slug}` + `product-listing:{channel}`                  |
+| `PAGE_*`                                         | `page:{slug}`, and `storefront-content:{channel}:{locale}` when slug is `storefront-*` |
+| `MENU_*`, `MENU_ITEM_*`                          | `navigation:{channel}`, `footer-menu:{channel}`                                        |
+| `CHANNEL_*`                                      | `channels`                                                                             |
+| Everything else                                  | Logged and skipped                                                                     |
+
+Catalog entries are **tag-addressable** — `applyCacheProfile` attaches the entity tag inside every `"use cache"` function, so `revalidateTag` alone busts every locale. Per-locale `revalidatePath` fan-out is therefore redundant for catalog data and is only used for CMS pages. `revalidateTag` takes the manifest profile (`resolveRevalidateCacheLifeProfile("products")`).
+
+**Don't** point Saleor webhooks directly at `/api/revalidate` while the app is installed (duplicate deliveries, doubled invalidation cost). Each delivery logs its `saleor-event` and `saleor-api-url`, so duplicates show up as two identical log lines per change — check there first if invalidation looks twice as busy as expected. Direct webhooks remain valid for self-hosted setups without the app (set `SALEOR_WEBHOOK_SECRET`).
 
 **Manual / emergency** (Bearer header, timing-safe; `?secret=` is deprecated):
 
@@ -159,7 +176,7 @@ curl -H "Authorization: Bearer <REVALIDATE_SECRET>" \
   "https://store.com/api/revalidate?all=1"
 ```
 
-Without webhooks, TTL takes over (catalog ~5 min, menus ~1 hr).
+Without webhooks, TTL takes over (catalog 1 hr, menus 1 hr).
 
 ### Debugging stale content
 
@@ -167,6 +184,27 @@ Without webhooks, TTL takes over (catalog ~5 min, menus ~1 hr).
 2. Tag exact? (`product:blue-hoodie` — slug must match).
 3. Force: `curl … "?tag=product:my-product"`.
 4. Translation still wrong language on `/pl/…`? Confirm a `PL` base translation exists; bust the tag; restart dev if you changed `src/config/locale.ts`.
+
+---
+
+## Cost controls
+
+Paper runs on Vercel, where the meters that matter are **function invocations + active CPU**, **edge middleware invocations**, **image transformations**, and **cache writes/bandwidth**. Caching decisions are cost decisions; these are the knobs, and each trades money against freshness.
+
+| Knob                                                   | Default        | Raises cost when…                     | Trade-off when tightened                         |
+| ------------------------------------------------------ | -------------- | ------------------------------------- | ------------------------------------------------ |
+| `catalog.revalidate` (`cache-life-profiles.data.mjs`)  | 1 hr           | Lowered — timer-driven regeneration   | Staler catalog if webhooks are not configured    |
+| `isCacheableListingView()` allowlist                   | first page     | Widened — one entry per permutation   | Filtered views stay uncached (a live fetch each) |
+| `NEXT_IMAGE_MIN_CACHE_TTL`                             | 31 days        | Lowered — re-optimizes the same image | In-place image replacements are served stale     |
+| `images.deviceSizes` / `imageSizes` (`next.config.js`) | trimmed ladder | Widened — a transformation per width  | No >1920px variants for 4K displays              |
+| `IMAGE_ALLOWED_HOSTS`                                  | unset          | Widened — third parties can bill you  | Non-Saleor image sources must be listed          |
+| `SALEOR_MIN_REQUEST_DELAY_MS`                          | 0 at runtime   | Raised — billed idle CPU per request  | Less protection against Saleor API rate limits   |
+
+Rules of thumb:
+
+- **A cache entry is only worth writing if it will be read again before it expires.** That is the whole argument for the listing allowlist, and the test to apply before caching anything new.
+- **Prefer webhook invalidation over short TTLs.** A TTL charges you continuously for freshness you need occasionally.
+- **Narrow the invalidation scope, not the cache.** Busting less on each event beats caching less.
 
 ---
 
@@ -178,6 +216,10 @@ Without webhooks, TTL takes over (catalog ~5 min, menus ~1 hr).
 ❌ Awaiting `searchParams` in a shell — collapses the route into a dynamic hole (move to an island)
 ❌ Raw `cacheLife("minutes")` / hand-rolled `cacheTag` — use `applyCacheProfile(CACHE_PROFILES.*)`
 ❌ Fetch-level `revalidate` inside `"use cache"` — `cacheLife` + webhooks own freshness
+❌ A catch-all `default:` in the webhook switch — unmapped events must log and skip, not purge
+❌ Busting listing tags on stock/metadata events — inventory sync would keep the grids permanently cold
+❌ Caching every filter/cursor permutation — unbounded cache writes for entries nobody re-reads
+❌ Shortening the `catalog` backstop to "make things fresher" — configure webhooks instead
 ❌ Wrapping only `<main>` in Suspense to silence a PPR error — fix the segment that owns the work
 ❌ Omitting `localeSlug` from cached fetches — all locales share one entry, wrong language
 ❌ Regional Saleor codes (`PL_PL`) in `graphqlLanguageCode` — Dashboard uses base codes (`PL`)

--- a/skills/saleor-paper-storefront/rules/data-caching.md
+++ b/skills/saleor-paper-storefront/rules/data-caching.md
@@ -150,6 +150,8 @@ Saleor event → saleor-paper-app → POST /api/revalidate → revalidateTag (+ 
 
 **The `saleor-event` header drives the scope.** `src/lib/webhook-events.ts` maps each event Paper acts on to an entity and an `affectsListing` flag; anything absent from that map is logged and skipped. Opting a new event into invalidation means adding it there. Never reintroduce a catch-all fallback — an unmapped event (orders, checkouts, customers) firing a catalog purge is a self-inflicted cost and cache-hit-rate problem.
 
+saleor-paper-app forwards that header on every entity POST. A POST without it (manual curl, older app) is treated as listing-affecting. After upgrading the app, click **Sync Webhooks** so Saleor delivers variant CRUD, stock, and metadata — stock events must arrive _with_ `saleor-event` or they bust the listing tag. Do not also subscribe the app to `PRODUCT_MEDIA_*`; Saleor already emits `PRODUCT_UPDATED` for media edits.
+
 | Event family                                                        | Storefront effect                                                                      |
 | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | `PRODUCT_*` / `PRODUCT_MEDIA_*` / variant created, updated, deleted | `product:{slug}` + `product-listing:{channel}`                                         |

--- a/skills/saleor-paper-storefront/rules/data-caching.md
+++ b/skills/saleor-paper-storefront/rules/data-caching.md
@@ -72,7 +72,7 @@ Always use `applyCacheProfile(CACHE_PROFILES.*, slugOrChannel)` — **never** ra
 Slug-scoped catalog entries carry **two** tags: the entity tag (`product:{slug}`) and the profile `sharedTag` (`products`). Entity webhooks bust the precise tag; `?all=1` revalidates shared tags so the whole catalog clears without enumerating slugs.
 Named `cacheLife` tiers (configured in `next.config.js`): `catalog` (products/categories/collections/listings/CMS pages) is `stale 5 min / revalidate 1 hr / expire 1 day`, `menus` ~1 hr (nav/footer) and ~5 min (storefront-content), `channels` longer.
 
-`revalidate` is a **backstop**, not the freshness mechanism — webhooks are. A short backstop regenerates every entry on a timer whether or not anything changed, which is pure cost; only shorten it if a deployment genuinely cannot run webhooks.
+`revalidate` is a **backstop**, not the freshness mechanism — webhooks are. Regeneration is request-triggered: a cold entry costs nothing. A short backstop on a _hot_ entry can approach one regeneration per window (1,440/day at 60s); only shorten it if a deployment genuinely cannot run webhooks.
 
 ### Listing grids
 
@@ -150,15 +150,15 @@ Saleor event → saleor-paper-app → POST /api/revalidate → revalidateTag (+ 
 
 **The `saleor-event` header drives the scope.** `src/lib/webhook-events.ts` maps each event Paper acts on to an entity and an `affectsListing` flag; anything absent from that map is logged and skipped. Opting a new event into invalidation means adding it there. Never reintroduce a catch-all fallback — an unmapped event (orders, checkouts, customers) firing a catalog purge is a self-inflicted cost and cache-hit-rate problem.
 
-| Event family                                     | Storefront effect                                                                      |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `PRODUCT_*` / `PRODUCT_MEDIA_*` (card-affecting) | `product:{slug}` + `product-listing:{channel}`                                         |
-| `PRODUCT_VARIANT_*` stock/metadata               | `product:{slug}` only — never the listing tag                                          |
-| `CATEGORY_*`, `COLLECTION_*`                     | `category:{slug}` / `collection:{slug}` + `product-listing:{channel}`                  |
-| `PAGE_*`                                         | `page:{slug}`, and `storefront-content:{channel}:{locale}` when slug is `storefront-*` |
-| `MENU_*`, `MENU_ITEM_*`                          | `navigation:{channel}`, `footer-menu:{channel}`                                        |
-| `CHANNEL_*`                                      | `channels`                                                                             |
-| Everything else                                  | Logged and skipped                                                                     |
+| Event family                                                        | Storefront effect                                                                      |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `PRODUCT_*` / `PRODUCT_MEDIA_*` / variant created, updated, deleted | `product:{slug}` + `product-listing:{channel}`                                         |
+| `PRODUCT_VARIANT_*` stock / metadata                                | `product:{slug}` only — never the listing tag                                          |
+| `CATEGORY_*`, `COLLECTION_*`                                        | `category:{slug}` / `collection:{slug}` + `product-listing:{channel}`                  |
+| `PAGE_*`                                                            | `page:{slug}`, and `storefront-content:{channel}:{locale}` when slug is `storefront-*` |
+| `MENU_*`, `MENU_ITEM_*`                                             | `navigation:{channel}`, `footer-menu:{channel}`                                        |
+| `CHANNEL_*`                                                         | `channels`                                                                             |
+| Everything else                                                     | Logged and skipped                                                                     |
 
 Catalog entries are **tag-addressable** — `applyCacheProfile` attaches the entity tag inside every `"use cache"` function, so `revalidateTag` alone busts every locale. Per-locale `revalidatePath` fan-out is therefore redundant for catalog data and is only used for CMS pages. `revalidateTag` takes the manifest profile (`resolveRevalidateCacheLifeProfile("products")`).
 
@@ -193,7 +193,7 @@ Paper runs on Vercel, where the meters that matter are **function invocations + 
 
 | Knob                                                   | Default        | Raises cost when…                     | Trade-off when tightened                         |
 | ------------------------------------------------------ | -------------- | ------------------------------------- | ------------------------------------------------ |
-| `catalog.revalidate` (`cache-life-profiles.data.mjs`)  | 1 hr           | Lowered — timer-driven regeneration   | Staler catalog if webhooks are not configured    |
+| `catalog.revalidate` (`cache-life-profiles.data.mjs`)  | 1 hr           | Lowered — request-triggered backstop  | Staler catalog if webhooks are not configured    |
 | `isCacheableListingView()` allowlist                   | first page     | Widened — one entry per permutation   | Filtered views stay uncached (a live fetch each) |
 | `NEXT_IMAGE_MIN_CACHE_TTL`                             | 31 days        | Lowered — re-optimizes the same image | In-place image replacements are served stale     |
 | `images.deviceSizes` / `imageSizes` (`next.config.js`) | trimmed ladder | Widened — a transformation per width  | No >1920px variants for 4K displays              |

--- a/skills/saleor-paper-storefront/rules/ui-images.md
+++ b/skills/saleor-paper-storefront/rules/ui-images.md
@@ -1,0 +1,100 @@
+---
+name: ui-images
+description: Images in Paper — Saleor already produces optimized thumbnails, so Vercel's optimizer must not redo that work. Covers the thumbnail ladder, remotePatterns allowlisting, minimumCacheTTL, deviceSizes/imageSizes budgets, and mandatory `sizes` on every fill image. Use when adding an <Image>, tuning image cost, debugging oversized requests, or touching next.config.js images config.
+---
+
+# Images
+
+Images are usually the largest line on a Paper storefront's Vercel bill — transformations and image cache writes both scale with the size of the catalog times the number of widths requested. The decisions here are about **not paying twice for the same optimization**.
+
+---
+
+## The one decision: Saleor optimizes, Vercel resizes
+
+> **Saleor already returns a compressed, format-converted thumbnail. Vercel's optimizer should only be picking a width — never redoing the encode from a 4000px original.**
+
+Saleor's `thumbnail(size:, format:)` field does real work server-side:
+
+- It snaps the requested size to a fixed ladder — `[32, 64, 128, 256, 512, 1024, 2048, 4096]` — and picks the **nearest** entry, not the next one up. Asking for 300 gives you 256.
+- It converts format (`format: WEBP`) and caches the result.
+- The returned URL is one of two shapes, and **this is the part that catches people out**:
+  - a **direct storage URL** once the thumbnail has been generated, or
+  - a **proxy URL** (`/thumbnail/{id}/{size}/{format}/`) that generates on first hit and 302s to storage.
+
+Both are stable per `(media id, size, format)`.
+
+**The consequence:** you cannot rewrite a Saleor image URL to change its width. The two URL shapes are not interchangeable, and rewriting a direct storage URL produces a 404. Any "custom loader that swaps the size segment" idea dies here — verify against `saleor/thumbnail/utils.py` (`get_image_or_proxy_url`) before trying it.
+
+So Paper asks Saleor for a sensibly-sized thumbnail, then lets `/_next/image` handle responsive widths from that already-small source.
+
+---
+
+## Cost model
+
+Vercel meters images two ways, and both are driven by **how many distinct URLs you generate**, not how many requests you serve:
+
+| Meter              | Driven by                                               |
+| ------------------ | ------------------------------------------------------- |
+| Transformations    | unique `(src, width, quality, format)` — first hit only |
+| Image cache writes | each transformation's result being stored               |
+
+Every entry in `deviceSizes`/`imageSizes` that a `sizes` attribute can select is a potential transformation **per source image**. A 5,000-product catalog with 8 candidate widths is 40,000 transformations before anyone visits a second page.
+
+That leads to three levers, all in [`next.config.js`](../../../next.config.js):
+
+1. **`minimumCacheTTL`** (Paper: 31 days, override with `NEXT_IMAGE_MIN_CACHE_TTL`). The Next default is 4 hours, which re-optimizes the same unchanged catalog image ~180×/month. Saleor URLs are stable, so a long TTL is nearly free correctness-wise — **except** that replacing an image in place in Saleor reuses the URL, so the old bytes serve until expiry. Uploading as new media always dodges this.
+2. **`deviceSizes` / `imageSizes`** — trimmed below the Next defaults. The 2048/3840 steps only serve 4K displays and are the most expensive to generate and store; the 16/32/48 steps are smaller than anything Paper renders.
+3. **`formats: ["image/webp"]`** — WebP only. AVIF compresses better but cold-encodes add ~500ms+ to the first `/_next/image` hit, which lands directly on LCP.
+
+---
+
+## `remotePatterns` is a security control, not just config
+
+`/_next/image` will fetch and optimize **any** host it is allowed to, and you are billed for it. A wildcard `hostname: "*"` in production lets anyone use the storefront as a free image CDN by hitting `/_next/image?url=…`.
+
+Paper builds the production allowlist from Saleor Cloud hosts plus the configured `NEXT_PUBLIC_SALEOR_API_URL` host, with extra sources (a DAM, a CMS) added via `IMAGE_ALLOWED_HOSTS`. The wildcard is **development-only**.
+
+---
+
+## Every `fill` image needs `sizes`
+
+Without `sizes`, Next assumes `100vw` and requests the widest candidate in `deviceSizes` — so an 80px cart thumbnail downloads a 1920px image. This is the single most common image bug and it is invisible locally, where everything is fast.
+
+Shared `sizes` strings live in [`src/lib/images.ts`](../../../src/lib/images.ts), keyed to the layout breakpoints they describe (`PLP_IMAGE_SIZES`, `PDP_MAIN_IMAGE_SIZES`, `CART_THUMBNAIL_IMAGE_SIZES`, …). Add a constant there rather than inlining a string, so the value stays reviewable next to the others.
+
+```tsx
+<Image
+	src={product.image}
+	alt={product.imageAlt || product.name}
+	fill
+	sizes={PLP_IMAGE_SIZES}
+	quality={PRODUCT_IMAGE_QUALITY}
+	className="object-cover"
+/>
+```
+
+Fixed-size images (`width`/`height`) are self-bounding and don't need `sizes` — Next requests roughly `width` and `width × 2`.
+
+`quality` is pinned at `PRODUCT_IMAGE_QUALITY` (75). Next 16 defaults `images.qualities` to `[75]`, so any other value is silently coerced unless you widen the allowlist — and each distinct quality multiplies the transformation count.
+
+---
+
+## Anti-patterns
+
+❌ `fill` without `sizes` — requests the widest variant for a thumbnail slot
+❌ `hostname: "*"` in `remotePatterns` for production — third parties bill you
+❌ A custom loader that rewrites Saleor thumbnail URL widths — the two URL shapes aren't interchangeable
+❌ Adding AVIF to `formats` — doubles transformations and cold-encode cost lands on LCP
+❌ Per-call-site `quality` values — each one is a separate transformation of the same image
+❌ Widening `deviceSizes` "just in case" — every entry is a transformation per source image
+❌ Requesting a huge Saleor `thumbnail(size:)` and letting Vercel shrink it — pay once, at the source
+
+---
+
+## Key files
+
+| File                              | Purpose                                                         |
+| --------------------------------- | --------------------------------------------------------------- |
+| `next.config.js` → `images`       | Allowlist, TTL, width ladders, formats                          |
+| `src/lib/images.ts`               | Shared `sizes` strings and quality constant                     |
+| `src/graphql/fragments/*.graphql` | `thumbnail(size:, format:)` selections — the source-side budget |

--- a/skills/saleor-paper-storefront/rules/ui-images.md
+++ b/skills/saleor-paper-storefront/rules/ui-images.md
@@ -25,7 +25,34 @@ Both are stable per `(media id, size, format)`.
 
 **The consequence:** you cannot rewrite a Saleor image URL to change its width. The two URL shapes are not interchangeable, and rewriting a direct storage URL produces a 404. Any "custom loader that swaps the size segment" idea dies here — verify against `saleor/thumbnail/utils.py` (`get_image_or_proxy_url`) before trying it.
 
-So Paper asks Saleor for a sensibly-sized thumbnail, then lets `/_next/image` handle responsive widths from that already-small source.
+Saleor Cloud fronts those storage URLs with CloudFront at `cache-control: max-age=604800`. So for catalog images Paper skips `/_next/image` altogether: it asks Saleor for **several rungs at once** and hands the browser a real `srcset`. The optimizer stays in the path only for sources Saleor never produced.
+
+---
+
+## The two pipelines
+
+`NEXT_PUBLIC_PAPER_IMAGE_PIPELINE` (default `saleor`) selects between them; `vercel` is the escape hatch if your Saleor deployment has no CDN in front of media.
+
+|                        | Saleor-native `srcset`                                       | `next/image`                                                                              |
+| ---------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Use for                | Product cards, PDP gallery — anything with a Saleor rung set | CMS uploads, local assets, category backgrounds, slots far smaller than the smallest rung |
+| Transformations billed | none                                                         | one per `(src, width, quality)`                                                           |
+| Served by              | Saleor's CDN                                                 | `/_next/image`                                                                            |
+| Width selection        | browser, from the rungs you requested                        | optimizer, from `deviceSizes`                                                             |
+
+The rung sets live in [`images.ts`](../../../src/lib/images.ts) (`CATALOG_CARD_RUNGS`, `PDP_GALLERY_RUNGS`) and must match the aliased GraphQL fields:
+
+```graphql
+thumbnail(size: 1024, format: WEBP) { url alt }
+thumbnail256: thumbnail(size: 256, format: WEBP) { url }
+thumbnail512: thumbnail(size: 512, format: WEBP) { url }
+```
+
+Feed those to `buildSaleorSrcSet()` in the mapper, pass the result to [`<SaleorImage>`](../../../src/ui/atoms/saleor-image.tsx), and it renders a plain `<img srcset sizes>`. With no `srcSet` it falls back to `next/image`, so a surface Saleor can't serve degrades on its own rather than breaking.
+
+Two costs to accept: each aliased rung materialises its own `Thumbnail` row on Saleor (one-time generation), and the `<img>` path has to ask for the LCP preload that `next/image` emits for `priority` — `<SaleorImage>` does this via `ReactDOM.preload`.
+
+Prefer `next/image` when the slot is far smaller than the smallest rung you request. The PDP thumbnail strip is 80px against a 512 floor, so letting the browser pick a rung would ship ~6× the bytes to save two cheap transformations — the wrong trade.
 
 ---
 
@@ -77,6 +104,23 @@ Fixed-size images (`width`/`height`) are self-bounding and don't need `sizes` �
 
 `quality` is pinned at `PRODUCT_IMAGE_QUALITY` (75). Next 16 defaults `images.qualities` to `[75]`, so any other value is silently coerced unless you widen the allowlist — and each distinct quality multiplies the transformation count.
 
+A `sizes` constant describes a **layout**, not a surface. `PLP_HERO_IMAGE_SIZES` is `100vw` because a hero is genuinely edge-to-edge; reusing it on a `lg:grid-cols-2` panel asks for double the pixels that surface ever displays. Match the constant to the column width, or add one.
+
+---
+
+## Every `thumbnail` selection needs `size:` and `format:`
+
+A bare `thumbnail { url }` is not "the default, which is fine". Saleor's `resolve_thumbnail` defaults to **256px in the image's original format** — so a PNG product shot arrives as a PNG, and Vercel is then billed to transcode it to WebP on every distinct width. Passing `format: WEBP` moves that conversion to Saleor, where it is free and cached.
+
+```graphql
+thumbnail(size: 256, format: WEBP) {
+	url
+	alt
+}
+```
+
+Pick `size:` from the ladder at or just above the largest rendered slot in **device** pixels — the CSS box times the retina factor. A 128px slot on a 2× screen needs 256, not 128.
+
 ---
 
 ## Anti-patterns
@@ -88,6 +132,10 @@ Fixed-size images (`width`/`height`) are self-bounding and don't need `sizes` �
 ❌ Per-call-site `quality` values — each one is a separate transformation of the same image
 ❌ Widening `deviceSizes` "just in case" — every entry is a transformation per source image
 ❌ Requesting a huge Saleor `thumbnail(size:)` and letting Vercel shrink it — pay once, at the source
+❌ A bare `thumbnail { url }` — 256px in the original format, so Vercel pays for the WebP conversion
+❌ Off-ladder sizes in an aliased rung set — Saleor snaps to the nearest rung, so the `srcset` width descriptor lies about the pixels delivered
+❌ Routing a Saleor-backed catalog image through `next/image` when a rung set exists — that is the duplicated encode this rule exists to prevent
+❌ Reusing `PLP_HERO_IMAGE_SIZES` on anything that isn't full-bleed — a half-width panel wants `SPLIT_PANEL_IMAGE_SIZES`
 
 ---
 

--- a/skills/saleor-paper-storefront/rules/ui-images.md
+++ b/skills/saleor-paper-storefront/rules/ui-images.md
@@ -50,7 +50,13 @@ thumbnail512: thumbnail(size: 512, format: WEBP) { url }
 
 Feed those to `buildSaleorSrcSet()` in the mapper, pass the result to [`<SaleorImage>`](../../../src/ui/atoms/saleor-image.tsx), and it renders a plain `<img srcset sizes>`. With no `srcSet` it falls back to `next/image`, so a surface Saleor can't serve degrades on its own rather than breaking.
 
-Two costs to accept: each aliased rung materialises its own `Thumbnail` row on Saleor (one-time generation), and the `<img>` path has to ask for the LCP preload that `next/image` emits for `priority` — `<SaleorImage>` does this via `ReactDOM.preload`.
+Three consequences of leaving the optimizer, all handled but none of them free:
+
+- **Connection setup moves onto the critical path.** `/_next/image` is same-origin, so it reuses the document's connection; Saleor's CDN is a different origin and costs DNS + TCP + TLS before the LCP image's first byte. The storefront root layout emits a `<link rel="preconnect">` from `saleorMediaPreconnectOrigin()`. It carries no `crossOrigin`, because plain `<img>` fetches are not CORS and a mismatched hint warms a connection the load cannot reuse. The origin is derived from `NEXT_PUBLIC_SALEOR_API_URL`; a deployment serving media from a separate domain needs its own hint.
+- **`priority` no longer implies a preload.** `next/image` emits one; the `<img>` path asks for it explicitly via `ReactDOM.preload`.
+- **A rung you have never requested comes back as a proxy URL, and cached pages bake it in.** `resolve_thumbnail` returns `/thumbnail/{id}/{size}/{format}/` until a `Thumbnail` row exists, so right after adding a rung the prerendered payload is full of URLs that 302 to storage — one extra round trip per image, on the LCP path. It self-heals: the first hit generates the file, the next resolve returns the storage URL, and the next re-render embeds it. On a large catalogue, crawl the new rungs before cutting traffic over. Verify with `curl -sI` on a fresh rung; a `302` means it has not been materialised yet.
+
+Type the rung fields as **required** where you consume them. If a fragment loses an alias, that should fail typecheck, not silently fall back to `/_next/image` and quietly start billing again.
 
 Prefer `next/image` when the slot is far smaller than the smallest rung you request. The PDP thumbnail strip is 80px against a 512 floor, so letting the browser pick a rung would ship ~6× the bytes to save two cheap transformations — the wrong trade.
 

--- a/skills/saleor-paper-storefront/scripts/compile-agents.mjs
+++ b/skills/saleor-paper-storefront/scripts/compile-agents.mjs
@@ -12,7 +12,7 @@ const skillRoot = join(__dirname, "..");
 const rulesDir = join(skillRoot, "rules");
 const outPath = join(skillRoot, "AGENTS.md");
 
-const RULE_COUNT = 31;
+const RULE_COUNT = 32;
 
 const catalog = [
 	{
@@ -88,9 +88,10 @@ const catalog = [
 		intro: "UI components and channel configuration control the visual layer and multi-currency support.",
 		rules: [
 			{ num: "5.1", file: "ui-components.md", title: "UI Components" },
-			{ num: "5.2", file: "ui-channels.md", title: "Channels & Multi-Currency" },
-			{ num: "5.3", file: "ui-locale-routing.md", title: "Locale & Channel URL Routing" },
-			{ num: "5.4", file: "ui-i18n.md", title: "next-intl (Code-Owned UI Strings)" },
+			{ num: "5.2", file: "ui-images.md", title: "Images" },
+			{ num: "5.3", file: "ui-channels.md", title: "Channels & Multi-Currency" },
+			{ num: "5.4", file: "ui-locale-routing.md", title: "Locale & Channel URL Routing" },
+			{ num: "5.5", file: "ui-i18n.md", title: "next-intl (Code-Owned UI Strings)" },
 		],
 	},
 	{

--- a/skills/saleor-paper-storefront/scripts/ensure-rule-frontmatter.mjs
+++ b/skills/saleor-paper-storefront/scripts/ensure-rule-frontmatter.mjs
@@ -80,6 +80,8 @@ const DESCRIPTIONS = {
 		"Post-design verification gates (autofixer loop): hard gate lint:design-tokens + tsc + lint; advisory PPR/LCP/a11y review. Use after molding UI to confirm it is Paper-correct, fast, and accessible.",
 	"ui-components.md":
 		"Creating/styling components with design tokens and shadcn/Radix primitives, extending cva matrices, the build-time variant registry. Use when building or restyling a UI component.",
+	"ui-images.md":
+		"Images in Paper — Saleor already produces optimized thumbnails, so Vercel's optimizer must not redo that work. Covers the thumbnail ladder, remotePatterns allowlisting, minimumCacheTTL, deviceSizes/imageSizes budgets, and mandatory `sizes` on every fill image. Use when adding an <Image>, tuning image cost, debugging oversized requests, or touching next.config.js images config.",
 	"ui-channels.md":
 		"Channels & multi-currency: URL channel segment, STOREFRONT_CHANNELS allowlist, the purchasability/fulfillment model, channel selector. Use when configuring channels or debugging 'product not purchasable'.",
 	"ui-locale-routing.md":

--- a/src/app/(storefront)/[locale]/[channel]/(main)/categories/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/categories/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { executePublicGraphQL } from "@/lib/graphql";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getCategoryData } from "@/lib/catalog/get-category-data";
+import { getCategoryListingPage, isCacheableListingView } from "@/lib/catalog/get-product-listing";
 import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "@/lib/catalog/locale-slugs";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { parseEditorJSToText } from "@/lib/editorjs";
@@ -18,8 +19,9 @@ import { buildStorefrontPath } from "@/lib/storefront-path";
 import { pickTranslatedSlug } from "@/lib/saleor-translations";
 import { CategoryPageClient } from "./client";
 
-// Prefetch: default (auto) under global `partialPrefetching`. Category tiles use
-// `prefetch={true}` so the hero + grid shell resolve at runtime with the link's params.
+// Prefetch: default (auto) under global `partialPrefetching` — App Shell only. Category
+// tiles deliberately do not opt into `prefetch={true}`: one runtime prefetch per tile in a
+// grid is a large invocation bill for navigation that already feels instant.
 
 type PageProps = {
 	params: Promise<{ locale: string; slug: string; channel: string }>;
@@ -129,13 +131,7 @@ async function CategoryProducts({
 }) {
 	const [params, searchParams] = await Promise.all([paramsPromise, searchParamsPromise]);
 
-	const paginationVariables = getPaginatedListVariables({ params: searchParams });
 	const sortBy = buildSortVariables(searchParams.sort);
-	const { filter, where } = buildProductListingConstraints({
-		priceRange: searchParams.price,
-		colors: searchParams.colors,
-		sizes: searchParams.sizes,
-	});
 
 	// Resolve via cached getCategoryData (handles translated URL slugs), then list by primary slug.
 	const category = await getCategoryData(params.slug, params.channel, params.locale);
@@ -143,19 +139,16 @@ async function CategoryProducts({
 		notFound();
 	}
 
-	const result = await executePublicGraphQL(ProductListByCategoryDocument, {
-		variables: {
-			slug: category.slug,
-			channel: params.channel,
-			...paginationVariables,
-			sortBy,
-			filter,
-			where,
-			...graphqlLanguageCodeVariables(params.locale),
-		},
-	});
+	const products = isCacheableListingView(searchParams)
+		? await getCategoryListingPage(category.slug, params.channel, params.locale, sortBy)
+		: await fetchFilteredCategoryListing({
+				searchParams,
+				categorySlug: category.slug,
+				channel: params.channel,
+				locale: params.locale,
+				sortBy,
+			});
 
-	const products = result.ok ? result.data.category?.products : null;
 	if (!products) {
 		notFound();
 	}
@@ -169,4 +162,40 @@ async function CategoryProducts({
 			totalCount={products.totalCount ?? productCards.length}
 		/>
 	);
+}
+
+/** Live fetch for filtered or paginated views — deliberately uncached (long tail). */
+async function fetchFilteredCategoryListing({
+	searchParams,
+	categorySlug,
+	channel,
+	locale,
+	sortBy,
+}: {
+	searchParams: Awaited<PageProps["searchParams"]>;
+	categorySlug: string;
+	channel: string;
+	locale: string;
+	sortBy: ReturnType<typeof buildSortVariables>;
+}) {
+	const paginationVariables = getPaginatedListVariables({ params: searchParams });
+	const { filter, where } = buildProductListingConstraints({
+		priceRange: searchParams.price,
+		colors: searchParams.colors,
+		sizes: searchParams.sizes,
+	});
+
+	const result = await executePublicGraphQL(ProductListByCategoryDocument, {
+		variables: {
+			slug: categorySlug,
+			channel,
+			...paginationVariables,
+			sortBy,
+			filter,
+			where,
+			...graphqlLanguageCodeVariables(locale),
+		},
+	});
+
+	return result.ok ? (result.data.category?.products ?? null) : null;
 }

--- a/src/app/(storefront)/[locale]/[channel]/(main)/collections/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/collections/[slug]/page.tsx
@@ -2,12 +2,18 @@ import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { type Metadata } from "next";
-import { ProductListByCollectionDocument, ProductOrderField, OrderDirection } from "@/gql/graphql";
+import {
+	ProductListByCollectionDocument,
+	ProductOrderField,
+	OrderDirection,
+	type ProductOrder,
+} from "@/gql/graphql";
 import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
 import { catalogPathSuffix, redirectToCanonicalCatalogSlug } from "@/lib/catalog/canonical-slug";
 import { CatalogIdentityBridge } from "@/lib/catalog/catalog-identity-bridge";
 import { getCollectionData } from "@/lib/catalog/get-collection-data";
+import { getCollectionListingPage, isCacheableListingView } from "@/lib/catalog/get-product-listing";
 import { buildCatalogPathSuffixByLocale, buildLocaleSlugMap } from "@/lib/catalog/locale-slugs";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { parseEditorJSToText } from "@/lib/editorjs";
@@ -120,35 +126,26 @@ async function CollectionProducts({
 }) {
 	const [params, searchParams] = await Promise.all([paramsPromise, searchParamsPromise]);
 
-	const paginationVariables = getPaginatedListVariables({ params: searchParams });
 	const sortBy = buildSortVariables(searchParams.sort) ?? {
 		field: ProductOrderField.Collection,
 		direction: OrderDirection.Asc,
 	};
-	const { filter, where } = buildProductListingConstraints({
-		priceRange: searchParams.price,
-		colors: searchParams.colors,
-		sizes: searchParams.sizes,
-	});
 
 	const collection = await getCollectionData(params.slug, params.channel, params.locale);
 	if (!collection) {
 		notFound();
 	}
 
-	const result = await executePublicGraphQL(ProductListByCollectionDocument, {
-		variables: {
-			slug: collection.slug,
-			channel: params.channel,
-			...paginationVariables,
-			sortBy,
-			filter,
-			where,
-			...graphqlLanguageCodeVariables(params.locale),
-		},
-	});
+	const products = isCacheableListingView(searchParams)
+		? await getCollectionListingPage(collection.slug, params.channel, params.locale, sortBy)
+		: await fetchFilteredCollectionListing({
+				searchParams,
+				collectionSlug: collection.slug,
+				channel: params.channel,
+				locale: params.locale,
+				sortBy,
+			});
 
-	const products = result.ok ? result.data.collection?.products : null;
 	if (!products) {
 		notFound();
 	}
@@ -162,4 +159,40 @@ async function CollectionProducts({
 			totalCount={products.totalCount ?? productCards.length}
 		/>
 	);
+}
+
+/** Live fetch for filtered or paginated views — deliberately uncached (long tail). */
+async function fetchFilteredCollectionListing({
+	searchParams,
+	collectionSlug,
+	channel,
+	locale,
+	sortBy,
+}: {
+	searchParams: Awaited<PageProps["searchParams"]>;
+	collectionSlug: string;
+	channel: string;
+	locale: string;
+	sortBy: ProductOrder;
+}) {
+	const paginationVariables = getPaginatedListVariables({ params: searchParams });
+	const { filter, where } = buildProductListingConstraints({
+		priceRange: searchParams.price,
+		colors: searchParams.colors,
+		sizes: searchParams.sizes,
+	});
+
+	const result = await executePublicGraphQL(ProductListByCollectionDocument, {
+		variables: {
+			slug: collectionSlug,
+			channel,
+			...paginationVariables,
+			sortBy,
+			filter,
+			where,
+			...graphqlLanguageCodeVariables(locale),
+		},
+	});
+
+	return result.ok ? (result.data.collection?.products ?? null) : null;
 }

--- a/src/app/(storefront)/[locale]/[channel]/(main)/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/page.tsx
@@ -6,6 +6,7 @@ import { resolveChannelCurrency } from "@/lib/channels/resolve-channel-currency"
 import { buildPolicyLabelValues } from "@/lib/content";
 import { formatContentLabel } from "@/lib/content/format-label";
 import { getStorefrontContent } from "@/lib/content/server";
+import { buildSaleorSrcSet } from "@/lib/images";
 import { pickTranslatedSlug } from "@/lib/saleor-translations";
 import { PaperSignEditorialPlaceholder } from "@/ui/components/shared/paper-sign";
 import { CategoryTileGrid, type CategoryTile } from "@/ui/sections/category-tile-grid/category-tile-grid";
@@ -26,9 +27,30 @@ export const metadata = {
 type FeaturedProduct = Awaited<ReturnType<typeof getFeaturedProducts>>[number];
 type HomeParams = Promise<{ locale: string; channel: string }>;
 
+/** Aliased rungs must stay in sync with CATALOG_CARD_RUNGS in src/lib/images.ts. */
+function productThumbnailSrcSet(product: FeaturedProduct) {
+	return buildSaleorSrcSet([
+		{ width: 256, url: product.thumbnail256?.url },
+		{ width: 512, url: product.thumbnail512?.url },
+		{ width: 1024, url: product.thumbnail?.url },
+	]);
+}
+
+function categoryBackgroundSrcSet(category: NonNullable<FeaturedProduct["category"]>) {
+	return buildSaleorSrcSet([
+		{ width: 256, url: category.backgroundImage256?.url },
+		{ width: 512, url: category.backgroundImage512?.url },
+		{ width: 1024, url: category.backgroundImage?.url },
+	]);
+}
+
 function pickImage(product: FeaturedProduct | undefined) {
 	if (!product?.thumbnail?.url) return null;
-	return { url: product.thumbnail.url, alt: product.thumbnail.alt || product.name || "" };
+	return {
+		url: product.thumbnail.url,
+		alt: product.thumbnail.alt || product.name || "",
+		srcSet: productThumbnailSrcSet(product),
+	};
 }
 
 /**
@@ -44,12 +66,14 @@ function buildCategoryTiles(products: readonly FeaturedProduct[], max = 3): Cate
 		if (!category?.slug || seen.has(category.slug)) continue;
 		seen.add(category.slug);
 		const categoryName = category.translation?.name || category.name;
-		const image = category.backgroundImage?.url ?? product.thumbnail?.url ?? null;
-		const imageAlt = category.backgroundImage?.alt || product.thumbnail?.alt || categoryName;
+		const background = category.backgroundImage;
+		const image = background?.url ?? product.thumbnail?.url ?? null;
+		const imageAlt = background?.alt || product.thumbnail?.alt || categoryName;
 		tiles.push({
 			title: categoryName,
 			href: `/categories/${pickTranslatedSlug(category)}`,
 			image,
+			imageSrcSet: background?.url ? categoryBackgroundSrcSet(category) : productThumbnailSrcSet(product),
 			imageAlt,
 		});
 		if (tiles.length >= max) break;
@@ -132,6 +156,7 @@ async function HomePageContent({ params }: { params: HomeParams }) {
 					heading={hero.heading}
 					subheading={hero.subheading}
 					image={heroImage?.url}
+					imageSrcSet={heroImage?.srcSet}
 					imageAlt={heroImage?.alt ?? ""}
 					primaryCta={{ label: hero.primaryCtaLabel, href: "/products" }}
 					placeholder={<PaperSignEditorialPlaceholder />}
@@ -162,6 +187,7 @@ async function HomePageContent({ params }: { params: HomeParams }) {
 				heading={editorial.heading}
 				paragraphs={editorial.paragraphs}
 				image={editorial.image ?? editorialFallbackImage?.url}
+				imageSrcSet={editorial.image ? undefined : editorialFallbackImage?.srcSet}
 				imageAlt={editorial.image ? editorial.imageAlt : (editorialFallbackImage?.alt ?? "")}
 				imageFit={editorial.image ? "cover" : "contain"}
 				imagePosition={editorial.imagePosition}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
@@ -200,6 +200,7 @@ async function ProductShell({
 	const galleryFallback = lcpImage ? (
 		<GalleryFallback
 			src={lcpImage.url}
+			srcSet={lcpImage.srcSet}
 			alt={lcpImage.alt ?? product.name}
 			imageCount={defaultImages.length}
 			showChrome={showGalleryChrome}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/products/[slug]/page.tsx
@@ -32,7 +32,8 @@ import {
 	VariantGalleryDynamic,
 	ProductRouteSkeleton,
 	VariantSectionDynamic,
-	VariantSectionSkeleton,
+	VariantSectionFallback,
+	variantSectionFallbackProps,
 	VariantSectionError,
 	getDefaultGalleryImages,
 	PDP_GALLERY_LAYOUT,
@@ -128,9 +129,10 @@ async function ProductShell({
 		getStorefrontContent(params.channel, params.locale),
 		resolveChannelCurrency(params.channel),
 	]);
+	const intlLocale = resolveLocaleFromSlug(params.locale).bcp47;
 	const policyLabels = buildPolicyLabelValues(content.policies, {
 		currency,
-		locale: resolveLocaleFromSlug(params.locale).bcp47,
+		locale: intlLocale,
 	});
 
 	if (!product) {
@@ -190,6 +192,18 @@ async function ProductShell({
 		inStock: product.isAvailable ?? false,
 		variantCount: product.productVariants?.totalCount ?? 0,
 	});
+
+	const variantSectionFallback = (
+		<VariantSectionFallback
+			{...variantSectionFallbackProps({
+				product,
+				content,
+				currency,
+				locale: intlLocale,
+				selectOptionsLabel: tPdp("selectOptions"),
+			})}
+		/>
+	);
 
 	const lcpImage = defaultImages[0];
 	// Reserve mobile dots / desktop thumbs in fallback when product has multiple images
@@ -256,7 +270,7 @@ async function ProductShell({
 						<h1 className="order-2 text-balance text-h1">{product.name}</h1>
 
 						<ErrorBoundary FallbackComponent={VariantSectionError}>
-							<Suspense fallback={<VariantSectionSkeleton />}>
+							<Suspense fallback={variantSectionFallback}>
 								<VariantSectionDynamic
 									product={product}
 									channel={params.channel}

--- a/src/app/(storefront)/[locale]/[channel]/(main)/products/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/products/page.tsx
@@ -7,6 +7,7 @@ import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
 import { executePublicGraphQL } from "@/lib/graphql";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { buildBrowsePageMetadata } from "@/lib/seo";
+import { getProductListingPage, isCacheableListingView } from "@/lib/catalog/get-product-listing";
 import { getStorefrontContent } from "@/lib/content/server";
 import { CategoryHero, toProductCardData } from "@/ui/components/plp";
 import { buildSortVariables, buildProductListingConstraints } from "@/ui/components/plp/filter-utils";
@@ -96,7 +97,6 @@ async function ProductsContent({
 }) {
 	const [params, searchParams] = await Promise.all([paramsPromise, searchParamsPromise]);
 
-	const paginationVariables = getPaginatedListVariables({ params: searchParams });
 	const sortBy = buildSortVariables(searchParams.sort);
 
 	// Parse category slugs from URL and resolve to IDs for server-side filtering
@@ -104,29 +104,21 @@ async function ProductsContent({
 	const categoryMap = await resolveCategorySlugsToIds(categorySlugs);
 	const categoryIds = Array.from(categoryMap.values()).map((c) => c.id);
 
-	const { filter, where } = buildProductListingConstraints({
-		priceRange: searchParams.price,
-		categoryIds,
-		colors: searchParams.colors,
-		sizes: searchParams.sizes,
-	});
+	// The unfiltered first page is the bulk of PLP traffic — serve it from cache.
+	// Filtered and paginated views stay live (see isCacheableListingView).
+	const products = isCacheableListingView(searchParams)
+		? await getProductListingPage(params.channel, params.locale, sortBy)
+		: await fetchFilteredProductListing({
+				searchParams,
+				categoryIds,
+				channel: params.channel,
+				locale: params.locale,
+				sortBy,
+			});
 
-	const result = await executePublicGraphQL(ProductListPaginatedDocument, {
-		variables: {
-			...paginationVariables,
-			channel: params.channel,
-			sortBy,
-			filter,
-			where,
-			...graphqlLanguageCodeVariables(params.locale),
-		},
-	});
-
-	if (!result.ok || !result.data.products) {
+	if (!products) {
 		notFound();
 	}
-
-	const products = result.data.products;
 	const productCards = products.edges.map((e) => toProductCardData(e.node, params.locale, params.channel));
 
 	// Build resolved categories array for the client (for active filter display)
@@ -145,6 +137,42 @@ async function ProductsContent({
 			resolvedCategories={resolvedCategories}
 		/>
 	);
+}
+
+/** Live fetch for filtered or paginated views — deliberately uncached (long tail). */
+async function fetchFilteredProductListing({
+	searchParams,
+	categoryIds,
+	channel,
+	locale,
+	sortBy,
+}: {
+	searchParams: Awaited<PageProps["searchParams"]>;
+	categoryIds: string[];
+	channel: string;
+	locale: string;
+	sortBy: ReturnType<typeof buildSortVariables>;
+}) {
+	const paginationVariables = getPaginatedListVariables({ params: searchParams });
+	const { filter, where } = buildProductListingConstraints({
+		priceRange: searchParams.price,
+		categoryIds,
+		colors: searchParams.colors,
+		sizes: searchParams.sizes,
+	});
+
+	const result = await executePublicGraphQL(ProductListPaginatedDocument, {
+		variables: {
+			...paginationVariables,
+			channel,
+			sortBy,
+			filter,
+			where,
+			...graphqlLanguageCodeVariables(locale),
+		},
+	});
+
+	return result.ok ? (result.data.products ?? null) : null;
 }
 
 /**

--- a/src/app/(storefront)/[locale]/layout.tsx
+++ b/src/app/(storefront)/[locale]/layout.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/config/locale";
 import { PersistBrowseLocaleCookie } from "@/ui/components/persist-browse-locale-cookie";
 import { getRootHtmlFontProps } from "@/lib/fonts";
+import { saleorMediaPreconnectOrigin } from "@/lib/images";
 
 /**
  * Root defaults + `og:locale` derived from the URL locale segment. Params-only, so it
@@ -69,9 +70,13 @@ export default async function LocaleRootLayout({
 	setRequestLocale(localeSlug);
 	const messages = await getMessages();
 	const htmlProps = getRootHtmlFontProps(htmlLang);
+	const mediaOrigin = saleorMediaPreconnectOrigin();
 
 	return (
 		<html {...htmlProps}>
+			{/* No crossOrigin: plain <img> fetches are not CORS, and a `crossorigin`
+			    preconnect would warm a connection the image load cannot reuse. */}
+			{mediaOrigin && <link rel="preconnect" href={mediaOrigin} />}
 			<body className="min-h-dvh font-sans">
 				<NextIntlClientProvider locale={localeSlug} messages={messages}>
 					<PersistBrowseLocaleCookie locale={localeSlug} />

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -13,119 +13,132 @@ import { ogBrandColors } from "@/lib/seo/og-brand-colors";
  * @example
  * /api/og?title=Product%20Name&price=€29.99
  * /api/og?title=Summer%20Collection&subtitle=New%20Arrivals
+ *
+ * Cost note: this is an unauthenticated endpoint whose output is a function of the query
+ * string, so every distinct parameter combination is a fresh Satori render (heavy CPU) and
+ * a fresh cache entry. Inputs are length-capped to bound the per-invocation cost. Nothing
+ * in the storefront generates these URLs today — metadata uses real product imagery — so a
+ * fork that does not need branded fallback images can delete this route outright.
  */
+
+const MAX_TITLE_LENGTH = 120;
+const MAX_SUBTITLE_LENGTH = 120;
+const MAX_PRICE_LENGTH = 32;
+
+function clamp(value: string | null, maxLength: number): string {
+	return (value ?? "").slice(0, maxLength);
+}
+
 export async function GET(request: NextRequest) {
 	const { searchParams } = request.nextUrl;
 
-	const title = searchParams.get("title") || "Saleor Store";
-	const subtitle = searchParams.get("subtitle") || "";
-	const price = searchParams.get("price") || "";
+	const title = clamp(searchParams.get("title"), MAX_TITLE_LENGTH) || "Saleor Store";
+	const subtitle = clamp(searchParams.get("subtitle"), MAX_SUBTITLE_LENGTH);
+	const price = clamp(searchParams.get("price"), MAX_PRICE_LENGTH);
 
 	return new ImageResponse(
-		(
+		<div
+			style={{
+				height: "100%",
+				width: "100%",
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				backgroundColor: ogBrandColors.background,
+				fontFamily: "system-ui, sans-serif",
+			}}
+		>
+			{/* Background pattern */}
 			<div
 				style={{
-					height: "100%",
-					width: "100%",
+					position: "absolute",
+					inset: 0,
+					backgroundImage: `radial-gradient(circle at 25px 25px, ${ogBrandColors.border} 2px, transparent 0)`,
+					backgroundSize: "50px 50px",
+					opacity: 0.5,
+				}}
+			/>
+
+			{/* Content container */}
+			<div
+				style={{
 					display: "flex",
 					flexDirection: "column",
 					alignItems: "center",
 					justifyContent: "center",
-					backgroundColor: ogBrandColors.background,
-					fontFamily: "system-ui, sans-serif",
+					padding: "60px",
+					maxWidth: "80%",
+					textAlign: "center",
 				}}
 			>
-				{/* Background pattern */}
-				<div
-					style={{
-						position: "absolute",
-						inset: 0,
-						backgroundImage: `radial-gradient(circle at 25px 25px, ${ogBrandColors.border} 2px, transparent 0)`,
-						backgroundSize: "50px 50px",
-						opacity: 0.5,
-					}}
-				/>
-
-				{/* Content container */}
+				{/* Logo/Brand */}
 				<div
 					style={{
 						display: "flex",
-						flexDirection: "column",
 						alignItems: "center",
-						justifyContent: "center",
-						padding: "60px",
-						maxWidth: "80%",
-						textAlign: "center",
+						marginBottom: "40px",
+						fontSize: "24px",
+						fontWeight: "600",
+						color: ogBrandColors.foreground,
+						letterSpacing: "-0.02em",
 					}}
 				>
-					{/* Logo/Brand */}
+					{/* Simple sparkle icon */}
+					<svg width="32" height="32" viewBox="0 0 24 24" fill="none" style={{ marginRight: "12px" }}>
+						<path
+							d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z"
+							fill={ogBrandColors.foreground}
+						/>
+					</svg>
+					saleor
+				</div>
+
+				{/* Title */}
+				<div
+					style={{
+						fontSize: "64px",
+						fontWeight: "700",
+						color: ogBrandColors.foreground,
+						lineHeight: 1.1,
+						letterSpacing: "-0.03em",
+						marginBottom: subtitle || price ? "20px" : "0",
+					}}
+				>
+					{title}
+				</div>
+
+				{/* Subtitle */}
+				{subtitle && (
 					<div
 						style={{
-							display: "flex",
-							alignItems: "center",
-							marginBottom: "40px",
-							fontSize: "24px",
+							fontSize: "28px",
+							color: ogBrandColors.mutedForeground,
+							marginBottom: price ? "20px" : "0",
+						}}
+					>
+						{subtitle}
+					</div>
+				)}
+
+				{/* Price */}
+				{price && (
+					<div
+						style={{
+							fontSize: "36px",
 							fontWeight: "600",
 							color: ogBrandColors.foreground,
-							letterSpacing: "-0.02em",
+							backgroundColor: ogBrandColors.card,
+							padding: "12px 32px",
+							borderRadius: "8px",
+							border: `2px solid ${ogBrandColors.border}`,
 						}}
 					>
-						{/* Simple sparkle icon */}
-						<svg width="32" height="32" viewBox="0 0 24 24" fill="none" style={{ marginRight: "12px" }}>
-							<path
-								d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z"
-								fill={ogBrandColors.foreground}
-							/>
-						</svg>
-						saleor
+						{price}
 					</div>
-
-					{/* Title */}
-					<div
-						style={{
-							fontSize: "64px",
-							fontWeight: "700",
-							color: ogBrandColors.foreground,
-							lineHeight: 1.1,
-							letterSpacing: "-0.03em",
-							marginBottom: subtitle || price ? "20px" : "0",
-						}}
-					>
-						{title}
-					</div>
-
-					{/* Subtitle */}
-					{subtitle && (
-						<div
-							style={{
-								fontSize: "28px",
-								color: ogBrandColors.mutedForeground,
-								marginBottom: price ? "20px" : "0",
-							}}
-						>
-							{subtitle}
-						</div>
-					)}
-
-					{/* Price */}
-					{price && (
-						<div
-							style={{
-								fontSize: "36px",
-								fontWeight: "600",
-								color: ogBrandColors.foreground,
-								backgroundColor: ogBrandColors.card,
-								padding: "12px 32px",
-								borderRadius: "8px",
-								border: `2px solid ${ogBrandColors.border}`,
-							}}
-						>
-							{price}
-						</div>
-					)}
-				</div>
+				)}
 			</div>
-		),
+		</div>,
 		{
 			width: 1200,
 			height: 630,

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -65,8 +65,9 @@ function parseWebhookPayload(payload: unknown): {
 		};
 	}
 
-	if (data.productVariant && typeof data.productVariant === "object") {
-		const variant = data.productVariant as Record<string, unknown>;
+	const variantNode = data.productVariant ?? data.variant;
+	if (variantNode && typeof variantNode === "object") {
+		const variant = variantNode as Record<string, unknown>;
 		const product = variant.product as Record<string, unknown> | undefined;
 		if (product) {
 			const category = product.category as Record<string, unknown> | undefined;

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -5,7 +5,6 @@ import { getStorefrontChannelSlugs } from "@/lib/channel-slugs";
 import {
 	CACHE_PROFILES,
 	buildTag,
-	buildPathsForAllLocales,
 	extractMenuSlugFromWebhookPayload,
 	extractPageSlugFromWebhookPayload,
 	planFullPurgeTagEntries,
@@ -16,9 +15,8 @@ import {
 	resolveRevalidateProfileForTag,
 	type CacheProfile,
 } from "@/lib/cache-manifest";
-import { getStorefrontLocaleSlugs } from "@/config/locale";
-import { buildStorefrontPath } from "@/lib/storefront-path";
 import { revalidateTags } from "@/lib/revalidate-tags";
+import { deliveryFingerprint, resolveWebhookEventScope, sanitizeLogValue } from "@/lib/webhook-events";
 import { extractBearerToken, verifySecret, verifyWebhookSignature } from "@/lib/api-auth";
 
 /**
@@ -110,27 +108,18 @@ function parseWebhookPayload(payload: unknown): {
 // Revalidation helper — keeps the switch cases DRY
 // ============================================================================
 
-function revalidateProfile(
-	profile: CacheProfile,
-	channel: string,
-	slug: string,
-	tagEntries: Array<{ tag: string; profile: CacheProfile["cacheProfile"] }>,
-	paths: string[],
-) {
+type TagEntry = { tag: string; profile: CacheProfile["cacheProfile"] };
+
+/**
+ * Queue an entity tag for revalidation.
+ *
+ * Catalog entries are tag-addressable: every `"use cache"` function in src/lib/catalog/
+ * carries the entity tag via `applyCacheProfile`, so `revalidateTag` alone busts every
+ * locale variant. The per-locale `revalidatePath` fan-out this used to also do was
+ * redundant with that — paths are now only used for CMS pages.
+ */
+function queueEntityTag(profile: CacheProfile, channel: string, slug: string, tagEntries: TagEntry[]) {
 	tagEntries.push({ tag: buildTag(profile, { slug, channel }), profile: profile.cacheProfile });
-
-	for (const path of buildPathsForAllLocales(profile, { channel, slug })) {
-		revalidatePath(path);
-		paths.push(path);
-	}
-}
-
-function revalidateProductListing(channel: string, paths: string[]) {
-	for (const locale of getStorefrontLocaleSlugs()) {
-		const path = buildStorefrontPath(locale, channel, "/products");
-		revalidatePath(path);
-		paths.push(path);
-	}
 }
 
 // ============================================================================
@@ -149,6 +138,23 @@ export async function POST(request: NextRequest) {
 		}
 	}
 
+	// Saleor sends the event type on every delivery. One line per delivery makes duplicate
+	// app + direct webhook subscriptions visible: same fingerprint twice = double billing.
+	const eventHeader = request.headers.get("saleor-event");
+	const delivery = {
+		event: sanitizeLogValue(eventHeader),
+		source: sanitizeLogValue(request.headers.get("saleor-api-url")),
+		fingerprint: deliveryFingerprint(rawBody),
+	};
+	console.log("[Revalidate] Delivery:", delivery);
+
+	const eventScope = resolveWebhookEventScope(eventHeader);
+
+	if (eventHeader && !eventScope) {
+		console.log("[Revalidate] Ignoring event Paper does not act on:", delivery);
+		return Response.json({ paths: [], tags: [], success: true, skipped: true, reason: "unhandled_event" });
+	}
+
 	try {
 		const payload = JSON.parse(rawBody);
 
@@ -156,10 +162,25 @@ export async function POST(request: NextRequest) {
 			console.log("[Revalidate] Raw payload:", JSON.stringify(payload, null, 2));
 		}
 
-		const { type, slug, channel, categorySlug } = parseWebhookPayload(payload);
+		const parsed = parseWebhookPayload(payload);
+		const { slug, channel } = parsed;
+		// The header is authoritative when present; payload shape is the fallback for
+		// manual POSTs and self-hosted setups that post without Saleor's headers.
+		const type = eventScope?.entity ?? parsed.type;
+
+		if (type === "unknown") {
+			console.log("[Revalidate] Skipping unrecognised payload:", delivery);
+			return Response.json({
+				paths: [],
+				tags: [],
+				success: true,
+				skipped: true,
+				reason: "unrecognised_payload",
+			});
+		}
 
 		const revalidatedPaths: string[] = [];
-		const tagEntries: Array<{ tag: string; profile: CacheProfile["cacheProfile"] }> = [];
+		const tagEntries: TagEntry[] = [];
 
 		if (type === "menu") {
 			const plan = planMenuRevalidation(slug, await getStorefrontChannelSlugs());
@@ -241,6 +262,15 @@ export async function POST(request: NextRequest) {
 			return Response.json({ paths: revalidatedPaths, tags: revalidatedTags, success: true });
 		}
 
+		if (type === "channel") {
+			const profile = CACHE_PROFILES.channels;
+			const revalidatedTags = await revalidateTags([
+				{ tag: buildTag(profile), profile: profile.cacheProfile },
+			]);
+			console.log("[Revalidate] Success:", { type, tags: revalidatedTags });
+			return Response.json({ paths: [], tags: revalidatedTags, success: true });
+		}
+
 		const targetChannel = channel || DefaultChannelSlug;
 		if (!targetChannel) {
 			return Response.json(
@@ -249,38 +279,43 @@ export async function POST(request: NextRequest) {
 			);
 		}
 
+		// Listing grids share one channel-scoped tag. Only events that can change a card
+		// bust it — stock and metadata churn would otherwise keep the grids permanently cold.
+		// No header (manual POST) is treated as listing-affecting, matching prior behaviour.
+		if (eventScope?.affectsListing ?? true) {
+			tagEntries.push({
+				tag: buildTag(CACHE_PROFILES.productListing, { channel: targetChannel }),
+				profile: CACHE_PROFILES.productListing.cacheProfile,
+			});
+		}
+
 		switch (type) {
 			case "product":
 				if (slug) {
-					revalidateProfile(CACHE_PROFILES.products, targetChannel, slug, tagEntries, revalidatedPaths);
+					queueEntityTag(CACHE_PROFILES.products, targetChannel, slug, tagEntries);
 				}
-				revalidateProductListing(targetChannel, revalidatedPaths);
-
-				if (categorySlug) {
-					revalidateProfile(
-						CACHE_PROFILES.categories,
-						targetChannel,
-						categorySlug,
-						tagEntries,
-						revalidatedPaths,
-					);
-				}
+				// A product event does not change category *metadata*; the category page's own
+				// cached hero is busted by category_* events. Nothing to do for categorySlug here.
 				break;
 
 			case "category":
 				if (slug) {
-					revalidateProfile(CACHE_PROFILES.categories, targetChannel, slug, tagEntries, revalidatedPaths);
+					queueEntityTag(CACHE_PROFILES.categories, targetChannel, slug, tagEntries);
 				}
 				break;
 
 			case "collection":
 				if (slug) {
-					revalidateProfile(CACHE_PROFILES.collections, targetChannel, slug, tagEntries, revalidatedPaths);
+					queueEntityTag(CACHE_PROFILES.collections, targetChannel, slug, tagEntries);
 				}
 				break;
 
-			default:
-				revalidateProductListing(targetChannel, revalidatedPaths);
+			default: {
+				// Every entity is handled above; a new WebhookEntity must fail typecheck here
+				// rather than silently fall through to a broad purge.
+				const unhandled: never = type;
+				throw new Error(`Unhandled webhook entity: ${String(unhandled)}`);
+			}
 		}
 
 		const revalidatedTags = await revalidateTags(tagEntries);

--- a/src/graphql/CheckoutCreate.graphql
+++ b/src/graphql/CheckoutCreate.graphql
@@ -17,7 +17,7 @@ mutation CheckoutCreate($channel: String!, $languageCode: LanguageCodeEnum!) {
 						id
 						name
 						slug
-						thumbnail {
+						thumbnail(size: 256, format: WEBP) {
 							url
 							alt
 						}

--- a/src/graphql/CheckoutFind.graphql
+++ b/src/graphql/CheckoutFind.graphql
@@ -22,7 +22,7 @@ query CheckoutFind($id: ID!, $languageCode: LanguageCodeEnum!) {
 					translation(languageCode: $languageCode) {
 						name
 					}
-					thumbnail {
+					thumbnail(size: 256, format: WEBP) {
 						url
 						alt
 					}

--- a/src/graphql/OrderByNumber.graphql
+++ b/src/graphql/OrderByNumber.graphql
@@ -50,7 +50,7 @@ fragment OrderFullDetails on Order {
 				translation(languageCode: $languageCode) {
 					name
 				}
-				thumbnail {
+				thumbnail(size: 256, format: WEBP) {
 					url
 					alt
 				}

--- a/src/graphql/OrderDetailsFragment.graphql
+++ b/src/graphql/OrderDetailsFragment.graphql
@@ -23,7 +23,7 @@ fragment OrderDetails on Order {
 				translation(languageCode: $languageCode) {
 					name
 				}
-				thumbnail {
+				thumbnail(size: 256, format: WEBP) {
 					url
 					alt
 				}

--- a/src/graphql/ProductDetails.graphql
+++ b/src/graphql/ProductDetails.graphql
@@ -25,7 +25,10 @@ query ProductDetails(
 			alt
 		}
 		media {
+			# Rung set for a Saleor-native srcset — keep in sync with PDP_GALLERY_RUNGS.
 			url(size: 2048, format: WEBP)
+			url512: url(size: 512, format: WEBP)
+			url1024: url(size: 1024, format: WEBP)
 			alt
 			type
 		}

--- a/src/graphql/ProductListByCategory.graphql
+++ b/src/graphql/ProductListByCategory.graphql
@@ -24,7 +24,9 @@ query ProductListByCategory(
 			slug
 		}
 		...CategoryLocaleSlugTranslations
-		backgroundImage {
+		# Full-bleed hero. Unsized, Saleor returns the 4096 rung in the original format —
+		# a multi-MB JPEG that Vercel then has to transcode.
+		backgroundImage(size: 2048, format: WEBP) {
 			url
 			alt
 		}

--- a/src/graphql/ProductListByCollection.graphql
+++ b/src/graphql/ProductListByCollection.graphql
@@ -24,7 +24,8 @@ query ProductListByCollection(
 			slug
 		}
 		...CollectionLocaleSlugTranslations
-		backgroundImage {
+		# Full-bleed hero — see ProductListByCategory for why this must be sized.
+		backgroundImage(size: 2048, format: WEBP) {
 			url
 			alt
 		}

--- a/src/graphql/ProductListItem.graphql
+++ b/src/graphql/ProductListItem.graphql
@@ -45,14 +45,23 @@ fragment ProductListItem on Product {
 			name
 			slug
 		}
-		backgroundImage {
+		# Homepage category tiles — never full-bleed, so a smaller rung than the hero.
+		backgroundImage(size: 1024, format: WEBP) {
 			url
 			alt
 		}
 	}
+	# Rung set for a Saleor-native srcset — keep in sync with CATALOG_CARD_RUNGS in
+	# src/lib/images.ts. Sizes must be exact ladder values; Saleor snaps to the nearest.
 	thumbnail(size: 1024, format: WEBP) {
 		url
 		alt
+	}
+	thumbnail256: thumbnail(size: 256, format: WEBP) {
+		url
+	}
+	thumbnail512: thumbnail(size: 512, format: WEBP) {
+		url
 	}
 	# Bestseller merchandising flag — fetch only the boolean by slug (new attribute API).
 	# Slugs must match PRODUCT_FLAG_SLUGS in src/lib/catalog/product-flags.ts.

--- a/src/graphql/ProductListItem.graphql
+++ b/src/graphql/ProductListItem.graphql
@@ -46,9 +46,16 @@ fragment ProductListItem on Product {
 			slug
 		}
 		# Homepage category tiles — never full-bleed, so a smaller rung than the hero.
+		# Rung set for a Saleor-native srcset; keep in sync with CATALOG_CARD_RUNGS.
 		backgroundImage(size: 1024, format: WEBP) {
 			url
 			alt
+		}
+		backgroundImage256: backgroundImage(size: 256, format: WEBP) {
+			url
+		}
+		backgroundImage512: backgroundImage(size: 512, format: WEBP) {
+			url
 		}
 	}
 	# Rung set for a Saleor-native srcset — keep in sync with CATALOG_CARD_RUNGS in

--- a/src/graphql/VariantDetailsFragment.graphql
+++ b/src/graphql/VariantDetailsFragment.graphql
@@ -49,7 +49,10 @@ fragment VariantDetails on ProductVariant {
 		}
 	}
 	media {
+		# Rung set for a Saleor-native srcset — keep in sync with PDP_GALLERY_RUNGS.
 		url(size: 2048, format: WEBP)
+		url512: url(size: 512, format: WEBP)
+		url1024: url(size: 1024, format: WEBP)
 		alt
 		type
 	}

--- a/src/lib/cache-life-profiles.data.mjs
+++ b/src/lib/cache-life-profiles.data.mjs
@@ -12,9 +12,10 @@ const WEEK = 7 * DAY;
 export const paperCacheLifeProfiles = {
 	// Webhook invalidation (PRODUCT_*, CATEGORY_*, COLLECTION_*) is the primary freshness
 	// mechanism for catalog data, so `revalidate` is only the backstop for a webhook that
-	// was never configured or was dropped. A 1-minute backstop meant every catalog entry
-	// regenerated ~1440x/day regardless of traffic; an hour keeps the safety net without
-	// paying for it continuously.
+	// was never configured or was dropped. Regeneration is request-triggered: a cold
+	// entry costs nothing. A hot entry with a 1-minute backstop can approach ~1440
+	// regenerations/day; an hour keeps the safety net without paying for it on every
+	// request.
 	catalog: {
 		stale: 5 * MINUTE,
 		revalidate: 1 * HOUR,

--- a/src/lib/cache-life-profiles.data.mjs
+++ b/src/lib/cache-life-profiles.data.mjs
@@ -10,10 +10,15 @@ const WEEK = 7 * DAY;
  * @type {Record<"catalog" | "menus" | "channels", CacheLifeTier>}
  */
 export const paperCacheLifeProfiles = {
+	// Webhook invalidation (PRODUCT_*, CATEGORY_*, COLLECTION_*) is the primary freshness
+	// mechanism for catalog data, so `revalidate` is only the backstop for a webhook that
+	// was never configured or was dropped. A 1-minute backstop meant every catalog entry
+	// regenerated ~1440x/day regardless of traffic; an hour keeps the safety net without
+	// paying for it continuously.
 	catalog: {
 		stale: 5 * MINUTE,
-		revalidate: 1 * MINUTE,
-		expire: 1 * HOUR,
+		revalidate: 1 * HOUR,
+		expire: 1 * DAY,
 	},
 	menus: {
 		stale: 5 * MINUTE,

--- a/src/lib/cache-life-profiles.ts
+++ b/src/lib/cache-life-profiles.ts
@@ -83,10 +83,10 @@ export const paperCacheLifeProfileDocs: Record<
 > = {
 	catalog: {
 		label: "Catalog",
-		usedFor: "Products, categories, collections, homepage featured",
+		usedFor: "Products, categories, collections, listings, homepage featured",
 		stale: "5 min",
-		revalidate: "1 min",
-		expire: "1 hour",
+		revalidate: "1 hour",
+		expire: "1 day",
 	},
 	menus: {
 		label: "Menus",

--- a/src/lib/cache-manifest.test.ts
+++ b/src/lib/cache-manifest.test.ts
@@ -224,6 +224,10 @@ describe("full purge tag planning", () => {
 		expect(tags).toContain("categories");
 		expect(tags).toContain("collections");
 		expect(tags).toContain("pages");
+		// "Revalidate all" must clear cached listing grids too, or the Dashboard button
+		// appears to work while the PLP keeps serving the old grid.
+		expect(tags).toContain("product-listing:us");
+		expect(tags).toContain("product-listing:uk");
 		expect(tags.some((t) => t.includes("{locale}"))).toBe(false);
 		expect(tags.some((t) => t.startsWith("product:"))).toBe(false);
 	});

--- a/src/lib/cache-manifest.ts
+++ b/src/lib/cache-manifest.ts
@@ -85,6 +85,23 @@ const profiles = {
 		pathPattern: "/{locale}/{channel}/pages/{slug}",
 		sharedTag: "pages",
 	},
+	/**
+	 * Listing grids (PLP, category, collection) for the *cacheable* views only —
+	 * see `isCacheableListingView` in src/lib/catalog/get-product-listing.ts.
+	 *
+	 * Deliberately channel-scoped rather than slug-scoped: one tag busts every
+	 * cached grid in a channel, and the entry count is bounded by the allowlist,
+	 * so precision here would buy nothing. Only product events that can change a
+	 * listing card revalidate it (`affectsListing` in src/lib/webhook-events.ts) —
+	 * stock and metadata churn must not, or the cache never stays warm.
+	 */
+	productListing: {
+		id: "product-listing",
+		label: "Product Listings",
+		cacheProfile: "catalog",
+		tagPattern: "product-listing:{channel}",
+		pathPattern: null,
+	},
 	navigation: {
 		id: "navigation",
 		label: "Navigation Menus",

--- a/src/lib/catalog/get-product-listing.test.ts
+++ b/src/lib/catalog/get-product-listing.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { isCacheableListingView } from "./get-product-listing";
+
+describe("isCacheableListingView", () => {
+	it("admits the unfiltered first page", () => {
+		expect(isCacheableListingView({})).toBe(true);
+	});
+
+	it("admits sort-only views — bounded by the number of sort options", () => {
+		expect(isCacheableListingView({ sort: "price_asc" })).toBe(true);
+		expect(isCacheableListingView({ sort: "newest" })).toBe(true);
+	});
+
+	it("rejects paginated views", () => {
+		expect(isCacheableListingView({ cursor: "WyIxIl0=" })).toBe(false);
+		expect(isCacheableListingView({ cursor: "WyIxIl0=", direction: "prev" })).toBe(false);
+	});
+
+	it("rejects filtered views — each permutation is a cache entry unlikely to be reread", () => {
+		expect(isCacheableListingView({ price: "0-50" })).toBe(false);
+		expect(isCacheableListingView({ colors: "blue" })).toBe(false);
+		expect(isCacheableListingView({ sizes: "m" })).toBe(false);
+		expect(isCacheableListingView({ categories: "shoes" })).toBe(false);
+	});
+
+	it("rejects a filtered first page even when sort is present", () => {
+		expect(isCacheableListingView({ sort: "price_asc", colors: "blue" })).toBe(false);
+	});
+});

--- a/src/lib/catalog/get-product-listing.ts
+++ b/src/lib/catalog/get-product-listing.ts
@@ -1,0 +1,159 @@
+import {
+	ProductListByCategoryDocument,
+	ProductListByCollectionDocument,
+	ProductListPaginatedDocument,
+	type ProductListByCategoryQuery,
+	type ProductListByCollectionQuery,
+	type ProductListPaginatedQuery,
+	type ProductOrder,
+} from "@/gql/graphql";
+import { ProductsPerPage } from "@/app/config";
+import { CACHE_PROFILES, applyCacheProfile } from "@/lib/cache-manifest";
+import { executePublicGraphQL } from "@/lib/graphql";
+import { graphqlLanguageCodeVariables } from "@/lib/graphql-locale";
+
+/**
+ * Cached listing grids for the high-traffic views.
+ *
+ * ## Why this exists
+ *
+ * Listing grids used to run uncached `executePublicGraphQL` inside the `searchParams`
+ * Suspense island, so every PLP request — every crawl, every page, every filter
+ * permutation — paid a full Saleor round trip and a full RSC render. That is the
+ * busiest surface in the storefront and it cached nothing.
+ *
+ * ## Why only *some* views
+ *
+ * Caching every filter/cursor permutation would trade invocation cost for unbounded
+ * cache-write cost. Instead {@link isCacheableListingView} admits only the unfiltered
+ * first page (in any sort order), which carries the bulk of real traffic. Filtered and
+ * deep-paginated views fall through to a live fetch and behave exactly as before.
+ *
+ * Entry count is therefore bounded by `sorts × locales × channels`, not by catalog size.
+ *
+ * ## Failure semantics
+ *
+ * A failed request **throws** so nothing is written to the cache; the island's
+ * ErrorBoundary renders and the next request retries. Returning null here instead would
+ * cache the failure and serve a 404 for the whole grid until the entry expired — one
+ * blip in Saleor becoming an hour of missing catalog. Only a genuinely absent entity
+ * returns null, which is a real result and safe to cache.
+ */
+
+export type ListingViewParams = {
+	cursor?: string | string[];
+	direction?: string | string[];
+	sort?: string;
+	price?: string;
+	colors?: string;
+	sizes?: string;
+	categories?: string;
+};
+
+/**
+ * True when a listing view is safe and worthwhile to cache.
+ *
+ * Any active filter, or any cursor, makes the view long-tail: it would add a cache
+ * entry that is unlikely to be read again before it expires.
+ */
+export function isCacheableListingView(params: ListingViewParams): boolean {
+	return !params.cursor && !params.price && !params.colors && !params.sizes && !params.categories;
+}
+
+type ListingConnection = NonNullable<ProductListPaginatedQuery["products"]>;
+
+/** Cached first page of the all-products grid. */
+export async function getProductListingPage(
+	channel: string,
+	localeSlug: string,
+	sortBy: ProductOrder | undefined,
+): Promise<ListingConnection | null> {
+	"use cache";
+	applyCacheProfile(CACHE_PROFILES.productListing, { channel });
+
+	const result = await executePublicGraphQL(ProductListPaginatedDocument, {
+		variables: {
+			first: ProductsPerPage,
+			after: null,
+			channel,
+			sortBy,
+			...graphqlLanguageCodeVariables(localeSlug),
+		},
+	});
+
+	if (!result.ok) {
+		throw new Error(
+			`[getProductListingPage] Failed to fetch listing for ${channel}: ${result.error.message}`,
+		);
+	}
+
+	return result.data.products ?? null;
+}
+
+type CategoryListing = NonNullable<ProductListByCategoryQuery["category"]>;
+
+/**
+ * Cached first page of a category grid.
+ * Takes the category's **primary** slug — callers resolve translated slugs via
+ * `getCategoryData` first, so this never needs `slugLanguageCode`.
+ */
+export async function getCategoryListingPage(
+	categorySlug: string,
+	channel: string,
+	localeSlug: string,
+	sortBy: ProductOrder | undefined,
+): Promise<CategoryListing["products"] | null> {
+	"use cache";
+	applyCacheProfile(CACHE_PROFILES.productListing, { channel });
+
+	const result = await executePublicGraphQL(ProductListByCategoryDocument, {
+		variables: {
+			slug: categorySlug,
+			channel,
+			first: ProductsPerPage,
+			after: null,
+			sortBy,
+			...graphqlLanguageCodeVariables(localeSlug),
+		},
+	});
+
+	if (!result.ok) {
+		throw new Error(
+			`[getCategoryListingPage] Failed to fetch category ${categorySlug} for ${channel}: ${result.error.message}`,
+		);
+	}
+
+	return result.data.category?.products ?? null;
+}
+
+type CollectionListing = NonNullable<ProductListByCollectionQuery["collection"]>;
+
+/** Cached first page of a collection grid. Takes the collection's **primary** slug. */
+export async function getCollectionListingPage(
+	collectionSlug: string,
+	channel: string,
+	localeSlug: string,
+	sortBy: ProductOrder | undefined,
+): Promise<CollectionListing["products"] | null> {
+	"use cache";
+	applyCacheProfile(CACHE_PROFILES.productListing, { channel });
+
+	const result = await executePublicGraphQL(ProductListByCollectionDocument, {
+		variables: {
+			slug: collectionSlug,
+			channel,
+			first: ProductsPerPage,
+			after: null,
+			sortBy,
+			...graphqlLanguageCodeVariables(localeSlug),
+		},
+	});
+
+	if (!result.ok) {
+		throw new Error(
+			`[getCollectionListingPage] Failed to fetch collection ${collectionSlug} for ${channel}: ${result.error.message}`,
+		);
+	}
+
+	return result.data.collection?.products ?? null;
+}

--- a/src/lib/graphql.ts
+++ b/src/lib/graphql.ts
@@ -141,6 +141,9 @@ class RequestQueue {
 		this.activeRequests++;
 
 		try {
+			if (this.minDelayMs <= 0) {
+				return await fn();
+			}
 			const [result] = await Promise.all([fn(), sleep(this.minDelayMs)]);
 			return result;
 		} finally {
@@ -179,9 +182,17 @@ function formatVariablesForLog(variables: Record<string, unknown>): string {
 	return parts.length > 0 ? `(${parts.join(", ")})` : "";
 }
 
+/**
+ * The inter-request delay exists to survive `next build`, where `generateStaticParams`
+ * fans out enough parallel requests to trip Saleor's rate limiter. At runtime the
+ * concurrency cap already bounds pressure, so the delay only adds latency to every
+ * request — and on Fluid Compute you pay for that wall time. Default it off at runtime.
+ */
+const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
+
 const requestQueue = new RequestQueue(
 	parseInt(process.env.SALEOR_MAX_CONCURRENT_REQUESTS || "3", 10),
-	parseInt(process.env.SALEOR_MIN_REQUEST_DELAY_MS || "200", 10),
+	parseInt(process.env.SALEOR_MIN_REQUEST_DELAY_MS || (isBuildPhase ? "200" : "0"), 10),
 );
 
 function getRetryConfig() {

--- a/src/lib/images.test.ts
+++ b/src/lib/images.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { buildSaleorSrcSet, CATALOG_CARD_RUNGS, PDP_GALLERY_RUNGS, SALEOR_THUMBNAIL_RUNGS } from "./images";
+
+describe("buildSaleorSrcSet", () => {
+	it("emits one width descriptor per usable rung", () => {
+		expect(
+			buildSaleorSrcSet([
+				{ width: 256, url: "https://cdn.test/a_256.webp" },
+				{ width: 512, url: "https://cdn.test/a_512.webp" },
+				{ width: 1024, url: "https://cdn.test/a_1024.webp" },
+			]),
+		).toBe(
+			"https://cdn.test/a_256.webp 256w, https://cdn.test/a_512.webp 512w, https://cdn.test/a_1024.webp 1024w",
+		);
+	});
+
+	it("drops rungs Saleor did not return", () => {
+		expect(
+			buildSaleorSrcSet([
+				{ width: 256, url: null },
+				{ width: 512, url: "https://cdn.test/a_512.webp" },
+				{ width: 1024, url: undefined },
+				{ width: 2048, url: "https://cdn.test/a_2048.webp" },
+			]),
+		).toBe("https://cdn.test/a_512.webp 512w, https://cdn.test/a_2048.webp 2048w");
+	});
+
+	// A one-candidate srcset tells the browser nothing `src` doesn't, and the
+	// undefined is what makes SaleorImage fall back to next/image.
+	it("returns undefined when fewer than two rungs are usable", () => {
+		expect(buildSaleorSrcSet([{ width: 512, url: "https://cdn.test/a_512.webp" }])).toBeUndefined();
+		expect(buildSaleorSrcSet([{ width: 512, url: null }])).toBeUndefined();
+		expect(buildSaleorSrcSet([])).toBeUndefined();
+	});
+
+	// Saleor returns the same storage URL for two sizes when both snap to one rung;
+	// repeating a descriptor would make the browser's selection non-deterministic.
+	it("keeps the first URL when a width repeats", () => {
+		expect(
+			buildSaleorSrcSet([
+				{ width: 512, url: "https://cdn.test/a_512.webp" },
+				{ width: 512, url: "https://cdn.test/duplicate.webp" },
+				{ width: 1024, url: "https://cdn.test/a_1024.webp" },
+			]),
+		).toBe("https://cdn.test/a_512.webp 512w, https://cdn.test/a_1024.webp 1024w");
+	});
+});
+
+describe("rung sets", () => {
+	// Off-ladder sizes snap to the nearest rung, so the width descriptor we publish
+	// would not match the pixels Saleor actually returns.
+	it("only request sizes that exist on Saleor's ladder", () => {
+		for (const rung of [...CATALOG_CARD_RUNGS, ...PDP_GALLERY_RUNGS]) {
+			expect(SALEOR_THUMBNAIL_RUNGS).toContain(rung);
+		}
+	});
+
+	it("lists rungs in ascending order so srcset descriptors are monotonic", () => {
+		for (const rungs of [CATALOG_CARD_RUNGS, PDP_GALLERY_RUNGS]) {
+			expect([...rungs]).toEqual([...rungs].sort((a, b) => a - b));
+		}
+	});
+});

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -17,8 +17,16 @@ export const FEATURED_COLLECTION_IMAGE_SIZES =
 export const PLP_IMAGE_SIZES =
 	"(max-width: 1024px) calc((100vw - 3rem) / 2), calc((min(100vw, 80rem) - 4rem - 3rem) / 3)";
 
-/** Full-width category/collection hero background */
+/**
+ * Full-bleed hero background. `100vw` is honest here — the image really does span the
+ * viewport — and `deviceSizes` in next.config.js caps the widest variant at 1920.
+ * Only use this on edge-to-edge surfaces; a half-width panel wants
+ * {@link SPLIT_PANEL_IMAGE_SIZES} instead, or it requests double the pixels it shows.
+ */
 export const PLP_HERO_IMAGE_SIZES = "100vw";
+
+/** Two-column section where the image occupies one column on desktop (lg:grid-cols-2) */
+export const SPLIT_PANEL_IMAGE_SIZES = "(max-width: 1024px) 100vw, 50vw";
 
 /** PDP main gallery: full width on mobile, half viewport on desktop split layout */
 export const PDP_MAIN_IMAGE_SIZES = "(max-width: 768px) 100vw, 50vw";
@@ -48,3 +56,65 @@ export const LCP_IMAGE_PRIORITY_COUNT = 1;
 
 /** Match Next.js default — higher values slow cold /_next/image encoding on Vercel */
 export const PRODUCT_IMAGE_QUALITY = 75;
+
+/* -------------------------------------------------------------------------- */
+/* Saleor-native responsive images                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Saleor's fixed thumbnail ladder (`saleor/thumbnail/__init__.py`). A requested size
+ * snaps to the **nearest** rung, not the next one up — asking for 300 returns 256.
+ * Only ever request values from this list, or the width you get back is not the
+ * width you put in the `srcset` descriptor.
+ */
+export const SALEOR_THUMBNAIL_RUNGS = [32, 64, 128, 256, 512, 1024, 2048, 4096] as const;
+
+/**
+ * Rungs requested for PLP/collection/category cards. Covers a 2-up mobile grid at 2x
+ * (~340px) through a 3-up desktop grid at 2x (~780px).
+ */
+export const CATALOG_CARD_RUNGS = [256, 512, 1024] as const;
+
+/** Rungs requested for the PDP gallery, which runs up to full-bleed on desktop. */
+export const PDP_GALLERY_RUNGS = [512, 1024, 2048] as const;
+
+/**
+ * Which pipeline serves catalog images.
+ *
+ * - `saleor` — plain `<img srcset>` pointing at Saleor's CDN-backed thumbnails.
+ *   Saleor has already produced a correctly-sized WebP, so this skips `/_next/image`
+ *   entirely and the transformation is never billed.
+ * - `vercel` — route everything through `next/image`. The escape hatch: set
+ *   `NEXT_PUBLIC_PAPER_IMAGE_PIPELINE=vercel` to revert without a code change.
+ *
+ * Surfaces without a Saleor rung set (local assets, CMS uploads) always use
+ * `next/image` regardless of this setting.
+ */
+export const PAPER_IMAGE_PIPELINE: "saleor" | "vercel" =
+	process.env.NEXT_PUBLIC_PAPER_IMAGE_PIPELINE === "vercel" ? "vercel" : "saleor";
+
+export interface SaleorSrcSetEntry {
+	/** Must be a value from {@link SALEOR_THUMBNAIL_RUNGS} that was actually requested. */
+	width: number;
+	url: string | null | undefined;
+}
+
+/**
+ * Builds a `srcset` from aliased Saleor thumbnail fields.
+ *
+ * Returns `undefined` for fewer than two usable rungs: a single-candidate `srcset`
+ * tells the browser nothing that `src` doesn't, and the caller uses that signal to
+ * fall back to `next/image`.
+ */
+export function buildSaleorSrcSet(entries: readonly SaleorSrcSetEntry[]): string | undefined {
+	const seen = new Set<number>();
+	const candidates: string[] = [];
+
+	for (const { width, url } of entries) {
+		if (!url || seen.has(width)) continue;
+		seen.add(width);
+		candidates.push(`${url} ${width}w`);
+	}
+
+	return candidates.length > 1 ? candidates.join(", ") : undefined;
+}

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -93,6 +93,29 @@ export const PDP_GALLERY_RUNGS = [512, 1024, 2048] as const;
 export const PAPER_IMAGE_PIPELINE: "saleor" | "vercel" =
 	process.env.NEXT_PUBLIC_PAPER_IMAGE_PIPELINE === "vercel" ? "vercel" : "saleor";
 
+/**
+ * Origin to `preconnect` when the Saleor pipeline is active.
+ *
+ * Under `next/image` every image is same-origin (`/_next/image?url=…`) and rides the
+ * connection the document already opened. Pointing `<img>` straight at Saleor makes the
+ * LCP image cross-origin, so without this hint the browser pays DNS + TCP + TLS before
+ * requesting its first byte.
+ *
+ * Returns `null` when the pipeline is `vercel` (the hint would open a socket nothing
+ * uses) or when the API URL is unset or unparseable. Assumes media is served from the
+ * API origin, which holds for Saleor Cloud and typical self-hosted deploys; a separate
+ * media domain needs its own hint.
+ */
+export function saleorMediaPreconnectOrigin(): string | null {
+	if (PAPER_IMAGE_PIPELINE !== "saleor") return null;
+
+	try {
+		return new URL(process.env.NEXT_PUBLIC_SALEOR_API_URL ?? "").origin;
+	} catch {
+		return null;
+	}
+}
+
 export interface SaleorSrcSetEntry {
 	/** Must be a value from {@link SALEOR_THUMBNAIL_RUNGS} that was actually requested. */
 	width: number;

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -40,6 +40,9 @@ export const PDP_MOSAIC_IMAGE_SIZES = "(max-width: 1024px) 50vw, 30vw";
 /** PDP desktop thumbnail strip */
 export const PDP_THUMBNAIL_IMAGE_SIZES = "80px";
 
+/** Cart drawer line item — fixed 80px slot (h-24 w-20) */
+export const CART_THUMBNAIL_IMAGE_SIZES = "80px";
+
 /** LCP candidate on Home, PLP, and PDP — only one high-priority image per viewport */
 export const LCP_IMAGE_PRIORITY_COUNT = 1;
 

--- a/src/lib/webhook-events.test.ts
+++ b/src/lib/webhook-events.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { deliveryFingerprint, resolveWebhookEventScope, sanitizeLogValue } from "./webhook-events";
+
+describe("resolveWebhookEventScope", () => {
+	it("returns null for events Paper does not act on", () => {
+		// The regression this guards: these used to fall through to a broad purge of
+		// the product listing on every locale.
+		expect(resolveWebhookEventScope("order_created")).toBeNull();
+		expect(resolveWebhookEventScope("checkout_updated")).toBeNull();
+		expect(resolveWebhookEventScope("customer_created")).toBeNull();
+		expect(resolveWebhookEventScope("gift_card_created")).toBeNull();
+	});
+
+	it("returns null for a missing header so payload inference can take over", () => {
+		expect(resolveWebhookEventScope(null)).toBeNull();
+		expect(resolveWebhookEventScope(undefined)).toBeNull();
+		expect(resolveWebhookEventScope("")).toBeNull();
+	});
+
+	it("maps catalog events to their entity", () => {
+		expect(resolveWebhookEventScope("product_updated")?.entity).toBe("product");
+		expect(resolveWebhookEventScope("product_variant_updated")?.entity).toBe("product");
+		expect(resolveWebhookEventScope("category_updated")?.entity).toBe("category");
+		expect(resolveWebhookEventScope("collection_updated")?.entity).toBe("collection");
+		expect(resolveWebhookEventScope("page_updated")?.entity).toBe("page");
+		expect(resolveWebhookEventScope("menu_item_updated")?.entity).toBe("menu");
+		expect(resolveWebhookEventScope("channel_updated")?.entity).toBe("channel");
+	});
+
+	it("marks events that can change a listing card", () => {
+		expect(resolveWebhookEventScope("product_created")?.affectsListing).toBe(true);
+		expect(resolveWebhookEventScope("product_updated")?.affectsListing).toBe(true);
+		expect(resolveWebhookEventScope("product_deleted")?.affectsListing).toBe(true);
+		expect(resolveWebhookEventScope("product_media_updated")?.affectsListing).toBe(true);
+		expect(resolveWebhookEventScope("product_variant_discounted_price_updated")?.affectsListing).toBe(true);
+	});
+
+	it("keeps stock and metadata churn off the listing cache", () => {
+		// These fire constantly on inventory sync; busting listings here would leave
+		// the listing cache permanently cold.
+		const detailOnly = [
+			"product_metadata_updated",
+			"product_variant_created",
+			"product_variant_updated",
+			"product_variant_deleted",
+			"product_variant_metadata_updated",
+			"product_variant_out_of_stock",
+			"product_variant_back_in_stock",
+			"product_variant_stock_updated",
+			"product_variant_out_of_stock_in_channel",
+			"product_variant_back_in_stock_in_channel",
+			"product_variant_out_of_stock_for_click_and_collect",
+			"product_variant_back_in_stock_for_click_and_collect",
+		];
+
+		for (const event of detailOnly) {
+			expect(resolveWebhookEventScope(event), event).toEqual({
+				entity: "product",
+				affectsListing: false,
+			});
+		}
+	});
+
+	it("normalizes header casing and whitespace", () => {
+		expect(resolveWebhookEventScope("PRODUCT_UPDATED")?.entity).toBe("product");
+		expect(resolveWebhookEventScope("  product_updated  ")?.entity).toBe("product");
+	});
+});
+
+describe("sanitizeLogValue", () => {
+	it("strips newlines so a header cannot forge extra log lines", () => {
+		expect(sanitizeLogValue("product_updated\n[Revalidate] forged")).toBe(
+			"product_updated[Revalidate] forged",
+		);
+		expect(sanitizeLogValue(null)).toBe("");
+	});
+});
+
+describe("deliveryFingerprint", () => {
+	it("is stable for the same body so duplicate deliveries are greppable", () => {
+		const body = JSON.stringify({ product: { slug: "blue-hoodie" } });
+		expect(deliveryFingerprint(body)).toBe(deliveryFingerprint(body));
+	});
+
+	it("differs for different bodies", () => {
+		expect(deliveryFingerprint('{"a":1}')).not.toBe(deliveryFingerprint('{"a":2}'));
+	});
+});

--- a/src/lib/webhook-events.test.ts
+++ b/src/lib/webhook-events.test.ts
@@ -33,6 +33,9 @@ describe("resolveWebhookEventScope", () => {
 		expect(resolveWebhookEventScope("product_deleted")?.affectsListing).toBe(true);
 		expect(resolveWebhookEventScope("product_media_updated")?.affectsListing).toBe(true);
 		expect(resolveWebhookEventScope("product_variant_discounted_price_updated")?.affectsListing).toBe(true);
+		expect(resolveWebhookEventScope("product_variant_created")?.affectsListing).toBe(true);
+		expect(resolveWebhookEventScope("product_variant_updated")?.affectsListing).toBe(true);
+		expect(resolveWebhookEventScope("product_variant_deleted")?.affectsListing).toBe(true);
 	});
 
 	it("keeps stock and metadata churn off the listing cache", () => {
@@ -40,9 +43,6 @@ describe("resolveWebhookEventScope", () => {
 		// the listing cache permanently cold.
 		const detailOnly = [
 			"product_metadata_updated",
-			"product_variant_created",
-			"product_variant_updated",
-			"product_variant_deleted",
 			"product_variant_metadata_updated",
 			"product_variant_out_of_stock",
 			"product_variant_back_in_stock",

--- a/src/lib/webhook-events.ts
+++ b/src/lib/webhook-events.ts
@@ -1,0 +1,114 @@
+/**
+ * Saleor webhook event → invalidation scope.
+ *
+ * Saleor sends the event type in the `saleor-event` header (lowercase snake_case,
+ * e.g. `product_updated`) on every delivery. Paper drives invalidation from that
+ * header rather than guessing from payload shape, so an event we do not act on
+ * (orders, checkouts, customers, …) is skipped instead of triggering a broad purge.
+ *
+ * `affectsListing` separates events that can change how a product appears in a grid
+ * (created/deleted/renamed/repriced/new media) from the high-frequency churn that
+ * cannot (stock movements, metadata writes). Inventory sync must not cost a listing
+ * cache entry.
+ *
+ * Event names verified against saleor/webhook/event_types.py (WebhookEventAsyncType).
+ */
+
+import { createHash } from "crypto";
+
+/** Entities Paper caches and can therefore invalidate. */
+export type WebhookEntity = "product" | "category" | "collection" | "page" | "menu" | "channel";
+
+export interface WebhookEventScope {
+	entity: WebhookEntity;
+	/** Event can add, remove, or reshape a listing card → bust the listing tag. */
+	affectsListing: boolean;
+}
+
+const PRODUCT_LISTING: WebhookEventScope = { entity: "product", affectsListing: true };
+const PRODUCT_DETAIL_ONLY: WebhookEventScope = { entity: "product", affectsListing: false };
+
+/**
+ * Events Paper acts on. Anything absent here is deliberately ignored — adding an entry
+ * is how you opt a new event into invalidation.
+ */
+const WEBHOOK_EVENT_SCOPES: Readonly<Record<string, WebhookEventScope>> = {
+	// Listing membership or card content changed.
+	product_created: PRODUCT_LISTING,
+	product_updated: PRODUCT_LISTING,
+	product_deleted: PRODUCT_LISTING,
+	product_media_created: PRODUCT_LISTING,
+	product_media_updated: PRODUCT_LISTING,
+	product_media_deleted: PRODUCT_LISTING,
+	product_variant_discounted_price_updated: PRODUCT_LISTING,
+
+	// PDP-only: never changes a listing card, and fires far more often.
+	product_metadata_updated: PRODUCT_DETAIL_ONLY,
+	product_variant_created: PRODUCT_DETAIL_ONLY,
+	product_variant_updated: PRODUCT_DETAIL_ONLY,
+	product_variant_deleted: PRODUCT_DETAIL_ONLY,
+	product_variant_metadata_updated: PRODUCT_DETAIL_ONLY,
+	product_variant_out_of_stock: PRODUCT_DETAIL_ONLY,
+	product_variant_back_in_stock: PRODUCT_DETAIL_ONLY,
+	product_variant_stock_updated: PRODUCT_DETAIL_ONLY,
+	product_variant_out_of_stock_in_channel: PRODUCT_DETAIL_ONLY,
+	product_variant_back_in_stock_in_channel: PRODUCT_DETAIL_ONLY,
+	product_variant_out_of_stock_for_click_and_collect: PRODUCT_DETAIL_ONLY,
+	product_variant_back_in_stock_for_click_and_collect: PRODUCT_DETAIL_ONLY,
+
+	category_created: { entity: "category", affectsListing: true },
+	category_updated: { entity: "category", affectsListing: true },
+	category_deleted: { entity: "category", affectsListing: true },
+
+	collection_created: { entity: "collection", affectsListing: true },
+	collection_updated: { entity: "collection", affectsListing: true },
+	collection_deleted: { entity: "collection", affectsListing: true },
+	collection_metadata_updated: { entity: "collection", affectsListing: false },
+
+	page_created: { entity: "page", affectsListing: false },
+	page_updated: { entity: "page", affectsListing: false },
+	page_deleted: { entity: "page", affectsListing: false },
+
+	menu_created: { entity: "menu", affectsListing: false },
+	menu_updated: { entity: "menu", affectsListing: false },
+	menu_deleted: { entity: "menu", affectsListing: false },
+	menu_item_created: { entity: "menu", affectsListing: false },
+	menu_item_updated: { entity: "menu", affectsListing: false },
+	menu_item_deleted: { entity: "menu", affectsListing: false },
+
+	channel_created: { entity: "channel", affectsListing: false },
+	channel_updated: { entity: "channel", affectsListing: false },
+	channel_deleted: { entity: "channel", affectsListing: false },
+	channel_status_changed: { entity: "channel", affectsListing: false },
+	channel_metadata_updated: { entity: "channel", affectsListing: false },
+};
+
+/**
+ * Resolve the `saleor-event` header to an invalidation scope.
+ * Returns null for events Paper does not act on, and for a missing header
+ * (manual/direct POSTs fall back to payload-shape inference).
+ */
+export function resolveWebhookEventScope(eventHeader: string | null | undefined): WebhookEventScope | null {
+	if (!eventHeader) return null;
+	return WEBHOOK_EVENT_SCOPES[eventHeader.trim().toLowerCase()] ?? null;
+}
+
+/** Header values are attacker-influenced; keep them on one log line. */
+export function sanitizeLogValue(value: string | null | undefined): string {
+	return value?.replace(/[\r\n]/g, "") ?? "";
+}
+
+/**
+ * Short fingerprint of a delivery body.
+ *
+ * Paper's docs warn against running direct Saleor webhooks alongside saleor-paper-app,
+ * because both deliver the same events and every invalidation is paid for twice. That
+ * misconfiguration is invisible in aggregate metrics but obvious in the logs: the same
+ * fingerprint arriving twice within seconds is a duplicate subscription, not two edits.
+ *
+ * Not used to *drop* deliveries — functions are multi-instance, so dedup here would be
+ * unreliable in exactly the way that silently loses invalidations.
+ */
+export function deliveryFingerprint(rawBody: string): string {
+	return createHash("sha1").update(rawBody).digest("hex").slice(0, 12);
+}

--- a/src/lib/webhook-events.ts
+++ b/src/lib/webhook-events.ts
@@ -7,9 +7,10 @@
  * (orders, checkouts, customers, …) is skipped instead of triggering a broad purge.
  *
  * `affectsListing` separates events that can change how a product appears in a grid
- * (created/deleted/renamed/repriced/new media) from the high-frequency churn that
- * cannot (stock movements, metadata writes). Inventory sync must not cost a listing
- * cache entry.
+ * (created/deleted/renamed/repriced/new media, plus variant CRUD — channel listing
+ * price and priceRange live on the variant) from the high-frequency churn that cannot
+ * (stock movements, metadata writes). Inventory sync must not cost a listing cache
+ * entry.
  *
  * Event names verified against saleor/webhook/event_types.py (WebhookEventAsyncType).
  */
@@ -41,12 +42,14 @@ const WEBHOOK_EVENT_SCOPES: Readonly<Record<string, WebhookEventScope>> = {
 	product_media_updated: PRODUCT_LISTING,
 	product_media_deleted: PRODUCT_LISTING,
 	product_variant_discounted_price_updated: PRODUCT_LISTING,
+	// Variant CRUD can change the card's priceRange. Saleor does not reliably also
+	// emit product_updated for a channel-listing price edit.
+	product_variant_created: PRODUCT_LISTING,
+	product_variant_updated: PRODUCT_LISTING,
+	product_variant_deleted: PRODUCT_LISTING,
 
-	// PDP-only: never changes a listing card, and fires far more often.
+	// PDP-only: cannot change a listing card, and fires far more often.
 	product_metadata_updated: PRODUCT_DETAIL_ONLY,
-	product_variant_created: PRODUCT_DETAIL_ONLY,
-	product_variant_updated: PRODUCT_DETAIL_ONLY,
-	product_variant_deleted: PRODUCT_DETAIL_ONLY,
 	product_variant_metadata_updated: PRODUCT_DETAIL_ONLY,
 	product_variant_out_of_stock: PRODUCT_DETAIL_ONLY,
 	product_variant_back_in_stock: PRODUCT_DETAIL_ONLY,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -105,5 +105,18 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-	matcher: ["/((?!_next/static|_next/image).*)"],
+	/**
+	 * Vercel bills an Edge Middleware invocation for every matched request, including the
+	 * ones this function immediately no-ops on. Excluding them here means they are never
+	 * invoked at all: API routes, the checkout surface, all `_next` internals, and any
+	 * path ending in a file extension (public/ assets, fonts, icons — this also covers
+	 * favicon.ico, robots.txt and sitemap.xml).
+	 *
+	 * Prefixes are anchored with `/` or `$` so they exclude `/api/…` without also
+	 * excluding a channel or locale slug that merely starts with those letters.
+	 *
+	 * The equivalent guards at the top of `middleware()` stay as a backstop for runtimes
+	 * that apply the matcher differently (self-hosted, `next start`).
+	 */
+	matcher: ["/((?!api/|api$|checkout/|checkout$|_next/|.*\\.[\\w]+$).*)"],
 };

--- a/src/ui/atoms/saleor-image.tsx
+++ b/src/ui/atoms/saleor-image.tsx
@@ -1,0 +1,82 @@
+import NextImage from "next/image";
+import { preload } from "react-dom";
+import { cn } from "@/lib/utils";
+import { PAPER_IMAGE_PIPELINE, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+
+export interface SaleorImageProps {
+	/** Largest requested rung — also the `src` fallback for browsers ignoring `srcSet`. */
+	src: string;
+	/**
+	 * Built by `buildSaleorSrcSet()` from aliased Saleor thumbnail fields. When absent
+	 * (local asset, CMS upload, single rung) the component falls back to `next/image`.
+	 */
+	srcSet?: string;
+	alt: string;
+	sizes: string;
+	className?: string;
+	/** LCP candidate: eager, high fetch priority, and a preload hint. */
+	priority?: boolean;
+	/** Overrides the `priority`-derived default — e.g. eager-load a carousel's first slide. */
+	loading?: "eager" | "lazy";
+	draggable?: boolean;
+	/** Only consulted on the `next/image` path — Saleor rungs are pre-encoded. */
+	quality?: number;
+}
+
+/**
+ * Fill-positioned catalog image that prefers Saleor's CDN over Vercel's optimizer.
+ *
+ * Saleor has already produced a correctly-sized, CloudFront-cached WebP for each rung
+ * we request, so sending those through `/_next/image` pays for a transformation that
+ * re-derives a file we already have. When a rung set is available this renders a plain
+ * `<img srcset>` against the CDN; otherwise it defers to `next/image`.
+ *
+ * See the `ui-images` rule for the decision table and the Saleor thumbnail mechanics.
+ */
+export function SaleorImage({
+	src,
+	srcSet,
+	alt,
+	sizes,
+	className,
+	priority = false,
+	loading,
+	draggable,
+	quality = PRODUCT_IMAGE_QUALITY,
+}: SaleorImageProps) {
+	if (PAPER_IMAGE_PIPELINE === "vercel" || !srcSet) {
+		return (
+			<NextImage
+				src={src}
+				alt={alt}
+				fill
+				sizes={sizes}
+				quality={quality}
+				className={className}
+				priority={priority}
+				loading={loading}
+				draggable={draggable}
+			/>
+		);
+	}
+
+	// next/image emits this for `priority`; the plain <img> path has to ask for it.
+	if (priority) {
+		preload(src, { as: "image", imageSrcSet: srcSet, imageSizes: sizes, fetchPriority: "high" });
+	}
+
+	return (
+		// eslint-disable-next-line @next/next/no-img-element -- deliberate: Saleor serves a CDN-cached WebP per rung, so next/image would bill a transformation to re-encode an already-optimal file.
+		<img
+			src={src}
+			srcSet={srcSet}
+			sizes={sizes}
+			alt={alt}
+			loading={loading ?? (priority ? "eager" : "lazy")}
+			fetchPriority={priority ? "high" : "auto"}
+			decoding="async"
+			draggable={draggable}
+			className={cn("absolute inset-0 h-full w-full", className)}
+		/>
+	);
+}

--- a/src/ui/components/cart/cart-drawer.tsx
+++ b/src/ui/components/cart/cart-drawer.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { formatMoney } from "@/lib/utils";
 import { localeConfig, resolveLocaleFromSlug } from "@/config/locale";
 import { hasDiscount } from "@/lib/pricing";
+import { CART_THUMBNAIL_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
 import { buildCheckoutPath } from "@paper/session-bridge";
 import type { CartContent, StorefrontPolicies } from "@/lib/content";
 import { formatContentLabel } from "@/lib/content/format-label";
@@ -258,6 +259,8 @@ export function CartDrawer({
 														src={line.variant.product.thumbnail.url}
 														alt={line.variant.product.thumbnail.alt ?? line.variant.product.name}
 														fill
+														sizes={CART_THUMBNAIL_IMAGE_SIZES}
+														quality={PRODUCT_IMAGE_QUALITY}
 														className="object-cover transition-transform duration-300 group-hover:scale-105"
 													/>
 												)}

--- a/src/ui/components/pdp/gallery-registry.tsx
+++ b/src/ui/components/pdp/gallery-registry.tsx
@@ -48,6 +48,8 @@ export interface GalleryRendererProps {
 
 export interface GalleryFallbackProps {
 	src: string;
+	/** Saleor rung `srcset` for the shell's LCP image; absent falls back to `next/image`. */
+	srcSet?: string;
 	alt: string;
 	imageCount: number;
 	/** Layout-specific extra chrome or placeholder tiles when the product has multiple images. */

--- a/src/ui/components/pdp/gallery-utils.ts
+++ b/src/ui/components/pdp/gallery-utils.ts
@@ -24,8 +24,12 @@ export interface GalleryImage {
 	srcSet?: string;
 }
 
-/** Aliased rungs from ProductDetails / VariantDetailsFragment media selections. */
-type GalleryMedia = { url: string; url512?: string; url1024?: string; alt?: string | null };
+/**
+ * Aliased rungs from the ProductDetails / VariantDetailsFragment media selections.
+ * Required, not optional: if a fragment loses an alias this must fail typecheck rather
+ * than quietly fall back to `/_next/image` and start billing transformations again.
+ */
+type GalleryMedia = { url: string; url512: string; url1024: string; alt?: string | null };
 
 function toGalleryImage(media: GalleryMedia): GalleryImage {
 	return {

--- a/src/ui/components/pdp/gallery-utils.ts
+++ b/src/ui/components/pdp/gallery-utils.ts
@@ -1,4 +1,5 @@
 import type { ProductShell, PdpVariant } from "@/lib/catalog/get-product-data";
+import { buildSaleorSrcSet } from "@/lib/images";
 
 /**
  * PDP product shape: shell fields from ProductDetails, plus variants merged by
@@ -16,21 +17,41 @@ export type Product = ProductShell & {
 };
 export type Variant = PdpVariant;
 
+export interface GalleryImage {
+	url: string;
+	alt: string | null | undefined;
+	/** Saleor rung `srcset`; absent means the surface falls back to `next/image`. */
+	srcSet?: string;
+}
+
+/** Aliased rungs from ProductDetails / VariantDetailsFragment media selections. */
+type GalleryMedia = { url: string; url512?: string; url1024?: string; alt?: string | null };
+
+function toGalleryImage(media: GalleryMedia): GalleryImage {
+	return {
+		url: media.url,
+		alt: media.alt,
+		srcSet: buildSaleorSrcSet([
+			{ width: 512, url: media.url512 },
+			{ width: 1024, url: media.url1024 },
+			{ width: 2048, url: media.url },
+		]),
+	};
+}
+
 export function getGalleryImages(
 	product: Product,
 	selectedVariant: Variant | null | undefined,
-): { url: string; alt: string | null | undefined }[] {
+): GalleryImage[] {
 	if (selectedVariant?.media && selectedVariant.media.length > 0) {
-		const variantImages = selectedVariant.media
-			.filter((m) => m.type === "IMAGE")
-			.map((m) => ({ url: m.url, alt: m.alt }));
+		const variantImages = selectedVariant.media.filter((m) => m.type === "IMAGE").map(toGalleryImage);
 		if (variantImages.length > 0) {
 			return variantImages;
 		}
 	}
 
 	if (product.media && product.media.length > 0) {
-		return product.media.filter((m) => m.type === "IMAGE").map((m) => ({ url: m.url, alt: m.alt }));
+		return product.media.filter((m) => m.type === "IMAGE").map(toGalleryImage);
 	}
 
 	if (product.thumbnail) {

--- a/src/ui/components/pdp/immersive-gallery-fallback.tsx
+++ b/src/ui/components/pdp/immersive-gallery-fallback.tsx
@@ -1,10 +1,11 @@
-import Image from "next/image";
-import { PDP_IMMERSIVE_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { PDP_IMMERSIVE_IMAGE_SIZES } from "@/lib/images";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { GalleryImageFrame, galleryImageFrameClass } from "@/ui/components/shared/gallery-image-frame";
 import { PDP_IMMERSIVE_IMAGE_HEIGHT } from "./gallery-layout";
 
 interface ImmersiveGalleryFallbackProps {
 	src: string;
+	srcSet?: string;
 	alt: string;
 	/** Accepted for a uniform gallery-registry signature; immersive shows a single hero frame. */
 	imageCount?: number;
@@ -16,7 +17,7 @@ interface ImmersiveGalleryFallbackProps {
  * Renders the first (default) image at the immersive size with LCP priority so
  * the streamed gallery does not shift layout.
  */
-export function ImmersiveGalleryFallback({ src, alt }: ImmersiveGalleryFallbackProps) {
+export function ImmersiveGalleryFallback({ src, srcSet, alt }: ImmersiveGalleryFallbackProps) {
 	return (
 		<div className="flex flex-col gap-4">
 			<div className="overflow-hidden">
@@ -27,13 +28,12 @@ export function ImmersiveGalleryFallback({ src, alt }: ImmersiveGalleryFallbackP
 							PDP_IMMERSIVE_IMAGE_HEIGHT,
 						)}
 					>
-						<Image
+						<SaleorImage
 							src={src}
+							srcSet={srcSet}
 							alt={alt}
-							fill
 							className="object-cover"
 							sizes={PDP_IMMERSIVE_IMAGE_SIZES}
-							quality={PRODUCT_IMAGE_QUALITY}
 							priority
 						/>
 					</GalleryImageFrame>

--- a/src/ui/components/pdp/immersive-gallery.tsx
+++ b/src/ui/components/pdp/immersive-gallery.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import * as React from "react";
-import Image from "next/image";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { PDP_IMMERSIVE_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { PDP_IMMERSIVE_IMAGE_SIZES } from "@/lib/images";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/components/ui/button";
 import { Carousel, CarouselContent, CarouselItem, type CarouselApi } from "@/ui/components/ui/carousel";
@@ -93,15 +93,13 @@ export function ImmersiveGallery({ images, productName }: ImmersiveGalleryProps)
 									className={cn("aspect-square w-full", PDP_IMMERSIVE_IMAGE_HEIGHT)}
 									aria-label={`${productName} - View ${index + 1}`}
 								>
-									<Image
+									<SaleorImage
 										src={image.url}
+										srcSet={image.srcSet}
 										alt={image.alt || `${productName} - View ${index + 1}`}
-										fill
 										draggable={false}
 										className="pointer-events-none object-cover"
 										sizes={PDP_IMMERSIVE_IMAGE_SIZES}
-										quality={PRODUCT_IMAGE_QUALITY}
-										priority={false}
 										loading={index === 0 ? "eager" : "lazy"}
 									/>
 								</GalleryImageZoomTrigger>

--- a/src/ui/components/pdp/index.ts
+++ b/src/ui/components/pdp/index.ts
@@ -33,7 +33,12 @@ export {
 // Cache Components - Dynamic PDP islands with Suspense support
 export { ProductRouteSkeleton } from "./product-route-skeleton";
 export { VariantGalleryDynamic, GallerySkeleton } from "./variant-gallery-dynamic";
-export { VariantSectionDynamic, VariantSectionSkeleton } from "./variant-section-dynamic";
+export { VariantSectionDynamic } from "./variant-section-dynamic";
+export {
+	VariantSectionFallback,
+	variantSectionFallbackProps,
+	VariantSectionSkeleton,
+} from "./variant-section-fallback";
 export { VariantSectionError } from "./variant-section-error";
 export {
 	getGalleryImages,

--- a/src/ui/components/pdp/mosaic-gallery-fallback.tsx
+++ b/src/ui/components/pdp/mosaic-gallery-fallback.tsx
@@ -1,9 +1,10 @@
-import Image from "next/image";
-import { PDP_MOSAIC_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { PDP_MOSAIC_IMAGE_SIZES } from "@/lib/images";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { GalleryImageFrame } from "@/ui/components/shared/gallery-image-frame";
 
 interface MosaicGalleryFallbackProps {
 	src: string;
+	srcSet?: string;
 	alt: string;
 	imageCount: number;
 	/** Omit placeholder tiles when image count may differ after searchParams resolve. */
@@ -17,6 +18,7 @@ interface MosaicGalleryFallbackProps {
  */
 export function MosaicGalleryFallback({
 	src,
+	srcSet,
 	alt,
 	imageCount,
 	showChrome = imageCount > 1,
@@ -26,13 +28,12 @@ export function MosaicGalleryFallback({
 	return (
 		<div className="grid grid-cols-2 gap-2 sm:gap-3">
 			<GalleryImageFrame className="aspect-[4/5] w-full">
-				<Image
+				<SaleorImage
 					src={src}
+					srcSet={srcSet}
 					alt={alt}
-					fill
 					className="object-cover"
 					sizes={PDP_MOSAIC_IMAGE_SIZES}
-					quality={PRODUCT_IMAGE_QUALITY}
 					priority
 				/>
 			</GalleryImageFrame>

--- a/src/ui/components/pdp/mosaic-gallery.tsx
+++ b/src/ui/components/pdp/mosaic-gallery.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Image from "next/image";
-import { PDP_MOSAIC_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { PDP_MOSAIC_IMAGE_SIZES } from "@/lib/images";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { type ImageCarouselImage } from "@/ui/components/ui/image-carousel";
 import { PDP_GALLERY_EMPTY_IMAGE_FRAME_CLASS } from "@/ui/components/shared/gallery-image-frame";
 import { GalleryImageZoomTrigger } from "@/ui/components/shared/gallery-image-zoom-trigger";
@@ -38,14 +38,12 @@ export function MosaicGallery({ images, productName }: MosaicGalleryProps) {
 						className="aspect-[4/5] w-full"
 						aria-label={image.alt || `${productName} - View ${index + 1}`}
 					>
-						<Image
+						<SaleorImage
 							src={image.url}
+							srcSet={image.srcSet}
 							alt={image.alt || `${productName} - View ${index + 1}`}
-							fill
 							className="pointer-events-none object-cover"
 							sizes={PDP_MOSAIC_IMAGE_SIZES}
-							quality={PRODUCT_IMAGE_QUALITY}
-							priority={false}
 							loading={index === 0 ? "eager" : "lazy"}
 						/>
 					</GalleryImageZoomTrigger>

--- a/src/ui/components/pdp/product-gallery-fallback.tsx
+++ b/src/ui/components/pdp/product-gallery-fallback.tsx
@@ -1,10 +1,11 @@
-import Image from "next/image";
-import { PDP_MAIN_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { PDP_MAIN_IMAGE_SIZES } from "@/lib/images";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { GalleryImageFrame } from "@/ui/components/shared/gallery-image-frame";
 import { ProductGalleryShell } from "./product-gallery-shell";
 
 interface ProductGalleryFallbackProps {
 	src: string;
+	srcSet?: string;
 	alt: string;
 	imageCount: number;
 	/** Omit chrome when image count may differ after searchParams resolve (e.g. multi-variant PDP) */
@@ -15,17 +16,22 @@ interface ProductGalleryFallbackProps {
  * Server-rendered PDP gallery for Suspense fallback.
  * Matches carousel chrome so the streamed gallery does not shift layout.
  */
-export function ProductGalleryFallback({ src, alt, imageCount, showChrome }: ProductGalleryFallbackProps) {
+export function ProductGalleryFallback({
+	src,
+	srcSet,
+	alt,
+	imageCount,
+	showChrome,
+}: ProductGalleryFallbackProps) {
 	return (
 		<ProductGalleryShell imageCount={imageCount} showChrome={showChrome}>
 			<GalleryImageFrame className="aspect-[4/5] w-full">
-				<Image
+				<SaleorImage
 					src={src}
+					srcSet={srcSet}
 					alt={alt}
-					fill
 					className="object-cover"
 					sizes={PDP_MAIN_IMAGE_SIZES}
-					quality={PRODUCT_IMAGE_QUALITY}
 					priority
 				/>
 			</GalleryImageFrame>

--- a/src/ui/components/pdp/product-route-skeleton.tsx
+++ b/src/ui/components/pdp/product-route-skeleton.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import { PDP_GALLERY_LAYOUT, PDP_LAYOUT_CLASSES } from "./gallery-layout";
 import { GallerySkeleton } from "./variant-gallery-dynamic";
-import { VariantSectionSkeleton } from "./variant-section-dynamic";
+import { VariantSectionSkeleton } from "./variant-section-fallback";
 
 interface ProductRouteSkeletonProps {
 	/**

--- a/src/ui/components/pdp/variant-section-dynamic.tsx
+++ b/src/ui/components/pdp/variant-section-dynamic.tsx
@@ -209,32 +209,3 @@ export async function VariantSectionDynamic({
 		</>
 	);
 }
-
-/**
- * Skeleton fallback for variant section.
- *
- * Uses delayed visibility (300ms) to prevent flash on fast loads.
- * Part of the static shell - shows while variant data streams in.
- */
-export function VariantSectionSkeleton() {
-	return (
-		<>
-			<div className="order-1 h-4 w-20 animate-pulse animate-skeleton-delayed rounded bg-muted opacity-0" />
-
-			<div className="order-3 mt-4 animate-pulse animate-skeleton-delayed space-y-6 opacity-0">
-				<div className="space-y-4">
-					<div className="h-4 w-16 rounded bg-muted" />
-					<div className="flex gap-2">
-						<div className="h-10 w-16 rounded bg-muted" />
-						<div className="h-10 w-16 rounded bg-muted" />
-						<div className="h-10 w-16 rounded bg-muted" />
-					</div>
-				</div>
-
-				<div className="h-8 w-24 rounded bg-muted" />
-
-				<div className="h-12 w-full rounded bg-muted" />
-			</div>
-		</>
-	);
-}

--- a/src/ui/components/pdp/variant-section-fallback.test.ts
+++ b/src/ui/components/pdp/variant-section-fallback.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultStorefrontContent } from "@/lib/content";
+import { variantSectionFallbackProps } from "./variant-section-fallback";
+
+describe("variantSectionFallbackProps", () => {
+	it("formats the shell price range and free-shipping trust line", () => {
+		const props = variantSectionFallbackProps({
+			product: {
+				category: { name: "Sneakers" },
+				pricing: {
+					priceRange: {
+						start: { gross: { amount: 90, currency: "USD" } },
+						stop: { gross: { amount: 90, currency: "USD" } },
+					},
+				},
+			},
+			content: defaultStorefrontContent,
+			currency: "USD",
+			locale: "en-US",
+			selectOptionsLabel: "Select options",
+		});
+
+		expect(props.categoryName).toBe("Sneakers");
+		expect(props.price).toBe("$90.00");
+		expect(props.selectOptionsLabel).toBe("Select options");
+		expect(props.secureCheckoutLabel).toBe(defaultStorefrontContent.surfaces.checkout.trust.secureCheckout);
+		expect(props.freeShippingTrustLabel).toMatch(/75/);
+	});
+
+	it("omits the free-shipping line when the channel has no threshold", () => {
+		const props = variantSectionFallbackProps({
+			product: {},
+			content: {
+				...defaultStorefrontContent,
+				policies: {
+					...defaultStorefrontContent.policies,
+					shipping: { freeShippingThreshold: null },
+				},
+			},
+			currency: "USD",
+			locale: "en-US",
+			selectOptionsLabel: "Select options",
+		});
+
+		expect(props.price).toBe("");
+		expect(props.freeShippingTrustLabel).toBeNull();
+	});
+});

--- a/src/ui/components/pdp/variant-section-fallback.tsx
+++ b/src/ui/components/pdp/variant-section-fallback.tsx
@@ -1,0 +1,144 @@
+import { ShoppingBag } from "lucide-react";
+
+import type { StorefrontContent } from "@/lib/content";
+import { formatMoney, formatMoneyRange } from "@/lib/utils";
+import { Button } from "@/ui/components/ui/button";
+
+/**
+ * Pulse bars for {@link ProductRouteSkeleton} — no product data is available yet.
+ * Do not use this as the in-page island fallback: after the Saleor CDN LCP image
+ * paints, pulse bars on the buy box read as a stall (the hole's RSC TTFB is often
+ * just over the 300ms delay).
+ */
+export function VariantSectionSkeleton() {
+	return (
+		<>
+			<div className="order-1 h-4 w-20 animate-pulse rounded bg-muted" />
+
+			<div className="order-3 mt-4 animate-pulse space-y-6">
+				<div className="space-y-4">
+					<div className="h-4 w-16 rounded bg-muted" />
+					<div className="flex gap-2">
+						<div className="h-10 w-16 rounded bg-muted" />
+						<div className="h-10 w-16 rounded bg-muted" />
+						<div className="h-10 w-16 rounded bg-muted" />
+					</div>
+				</div>
+
+				<div className="h-8 w-24 rounded bg-muted" />
+
+				<div className="h-12 w-full rounded bg-muted" />
+			</div>
+		</>
+	);
+}
+
+export interface VariantSectionFallbackProps {
+	categoryName?: string | null;
+	price: string;
+	selectOptionsLabel: string;
+	secureCheckoutLabel: string;
+	freeShippingTrustLabel?: string | null;
+}
+
+type FallbackProduct = {
+	category?: { name?: string | null } | null;
+	pricing?: {
+		priceRange?: {
+			start?: { gross?: { amount: number; currency: string } | null } | null;
+			stop?: { gross?: { amount: number; currency: string } | null } | null;
+		} | null;
+	} | null;
+};
+
+/** Props for {@link VariantSectionFallback} from data the PDP shell already has. */
+export function variantSectionFallbackProps(input: {
+	product: FallbackProduct;
+	content: StorefrontContent;
+	currency: string;
+	locale: string;
+	selectOptionsLabel: string;
+}): VariantSectionFallbackProps {
+	const { product, content, currency, locale, selectOptionsLabel } = input;
+	const threshold = content.policies.shipping.freeShippingThreshold;
+	return {
+		categoryName: product.category?.name,
+		price:
+			formatMoneyRange(
+				{
+					start: product.pricing?.priceRange?.start?.gross,
+					stop: product.pricing?.priceRange?.stop?.gross,
+				},
+				locale,
+			) || "",
+		selectOptionsLabel,
+		secureCheckoutLabel: content.surfaces.checkout.trust.secureCheckout,
+		freeShippingTrustLabel:
+			threshold != null
+				? `${content.surfaces.cart.trust.freeShippingPrefix} ${formatMoney(threshold, currency, locale)}`
+				: null,
+	};
+}
+
+/**
+ * Server-only buy-box chrome from the PPR shell (category, price range, disabled ATC).
+ * Must not import `AddToCart` — that client island would land in the static fallback
+ * with no `<form>` and pull `useFormStatus` into every PDP shell.
+ * Selectors stay in the searchParams island.
+ */
+export function VariantSectionFallback({
+	categoryName,
+	price,
+	selectOptionsLabel,
+	secureCheckoutLabel,
+	freeShippingTrustLabel,
+}: VariantSectionFallbackProps) {
+	return (
+		<>
+			<div className="order-1 flex items-center gap-2">
+				{categoryName ? <span className="text-sm text-muted-foreground">{categoryName}</span> : null}
+			</div>
+
+			<div className="order-3 mt-4 space-y-6" aria-busy="true">
+				<div className="space-y-4">
+					<div className="flex items-baseline gap-3">
+						<span className="text-2xl font-semibold tabular-nums tracking-tight">{price}</span>
+					</div>
+					<Button type="button" size="lg" disabled className="h-14 w-full text-base font-medium">
+						<ShoppingBag className="mr-2 h-5 w-5" />
+						{selectOptionsLabel}
+					</Button>
+					<div className="flex items-center justify-center gap-6 pt-2 text-xs text-muted-foreground">
+						<span className="flex items-center gap-1.5">
+							<svg
+								className="h-4 w-4"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="1.5"
+							>
+								<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+							</svg>
+							{secureCheckoutLabel}
+						</span>
+						{freeShippingTrustLabel ? (
+							<span className="flex items-center gap-1.5">
+								<svg
+									className="h-4 w-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="1.5"
+								>
+									<path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
+									<path d="M9 22V12h6v10" />
+								</svg>
+								{freeShippingTrustLabel}
+							</span>
+						) : null}
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/src/ui/components/plp/product-card-base.tsx
+++ b/src/ui/components/plp/product-card-base.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { formatProductPrice } from "./format-product-price";
 import { formatPrice } from "./utils";
 import { PLP_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import type { ProductCardData } from "./product-card-data";
 import { ProductCardLink } from "./product-card-link";
 
@@ -26,12 +27,11 @@ export function ProductCardBase({
 		<article className="group">
 			<div className="relative mb-4 aspect-[3/4] overflow-hidden rounded-card bg-secondary">
 				<ProductCardLink href={product.href} className="absolute inset-0 z-0 block" aria-label={product.name}>
-					<Image
+					<SaleorImage
 						src={product.image}
+						srcSet={product.imageSrcSet}
 						alt={product.imageAlt || product.name}
-						fill
 						sizes={imageSizes}
-						quality={PRODUCT_IMAGE_QUALITY}
 						className={cn(
 							"object-cover transition-all duration-500 ease-out md:group-hover:scale-105",
 							product.hoverImage && "md:group-hover:opacity-0",

--- a/src/ui/components/plp/product-card-data.ts
+++ b/src/ui/components/plp/product-card-data.ts
@@ -14,6 +14,8 @@ export interface ProductCardData {
 	/** BCP 47 locale for price formatting (from the route locale at build/render time). */
 	localeBcp47?: string;
 	image: string;
+	/** Saleor rung `srcset`; absent means the card falls back to `next/image`. */
+	imageSrcSet?: string;
 	imageAlt?: string;
 	hoverImage?: string | null;
 	href: string;

--- a/src/ui/components/plp/utils.ts
+++ b/src/ui/components/plp/utils.ts
@@ -9,6 +9,7 @@ import { calculateDiscountPercent, hasDiscount, hasDiscountInPriceRange } from "
 import { buildStorefrontPath } from "@/lib/storefront-path";
 import { pickTranslatedName, pickTranslatedSlug } from "@/lib/saleor-translations";
 import { isBestseller } from "@/lib/catalog/product-flags";
+import { buildSaleorSrcSet } from "@/lib/images";
 
 type ListVariantNode = NonNullable<
 	NonNullable<ProductListItemFragment["productVariants"]>["edges"][number]
@@ -115,6 +116,11 @@ export function toProductCardData(
 		discountPercent,
 		currency: startPrice?.currency ?? localeConfig.fallbackCurrency,
 		image: product.thumbnail?.url ?? "/placeholder.svg",
+		imageSrcSet: buildSaleorSrcSet([
+			{ width: 256, url: product.thumbnail256?.url },
+			{ width: 512, url: product.thumbnail512?.url },
+			{ width: 1024, url: product.thumbnail?.url },
+		]),
 		imageAlt: product.thumbnail?.alt ?? productName,
 		hoverImage: null,
 		localeBcp47: resolveLocaleFromSlug(locale).bcp47,

--- a/src/ui/components/ui/image-carousel.tsx
+++ b/src/ui/components/ui/image-carousel.tsx
@@ -11,6 +11,7 @@ import {
 	GalleryImageZoomTrigger,
 } from "@/ui/components/shared/gallery-image-zoom-trigger";
 import { PDP_MAIN_IMAGE_SIZES, PDP_THUMBNAIL_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { cn } from "@/lib/utils";
 import {
 	Carousel,
@@ -26,6 +27,8 @@ import {
 export interface ImageCarouselImage {
 	url: string;
 	alt?: string | null;
+	/** Saleor rung `srcset`; absent falls back to `next/image`. */
+	srcSet?: string;
 }
 
 interface ImageCarouselProps {
@@ -133,27 +136,23 @@ export function ImageCarousel({
 										onClick={() => onImageClick(index)}
 										aria-label={image.alt || `${productName} - View ${index + 1}`}
 									>
-										<Image
+										<SaleorImage
 											src={image.url}
+											srcSet={image.srcSet}
 											alt={image.alt || `${productName} - View ${index + 1}`}
-											fill
 											className="object-cover"
 											sizes={PDP_MAIN_IMAGE_SIZES}
-											quality={PRODUCT_IMAGE_QUALITY}
-											priority={false}
 											loading={index === 0 ? "eager" : "lazy"}
 										/>
 									</GalleryImageZoomTrigger>
 								) : (
 									<div className="relative h-full min-h-0 w-full overflow-hidden">
-										<Image
+										<SaleorImage
 											src={image.url}
+											srcSet={image.srcSet}
 											alt={image.alt || `${productName} - View ${index + 1}`}
-											fill
 											className="object-cover"
 											sizes={PDP_MAIN_IMAGE_SIZES}
-											quality={PRODUCT_IMAGE_QUALITY}
-											priority={false}
 											loading={index === 0 ? "eager" : "lazy"}
 										/>
 									</div>
@@ -198,6 +197,9 @@ export function ImageCarousel({
 							aria-label={`${productName} - Thumbnail ${index + 1}`}
 							aria-current={selectedIndex === index ? "true" : undefined}
 						>
+							{/* Stays on next/image: the smallest gallery rung is 512, and letting the
+							    browser pick that for an 80px slot ships ~6x the bytes. Two cheap
+							    transformations beat the oversized CDN fetch here. */}
 							<Image
 								src={image.url}
 								alt=""

--- a/src/ui/sections/category-tile-grid/category-tile-grid.tsx
+++ b/src/ui/sections/category-tile-grid/category-tile-grid.tsx
@@ -55,8 +55,11 @@ function TileLink({
 	className: string;
 	children: React.ReactNode;
 }) {
+	// Default (auto) prefetch, not `prefetch={true}`: under `partialPrefetching` a grid of
+	// tiles would otherwise request a full RSC payload per tile on viewport entry. Auto
+	// shares one App Shell per route, which is what makes the navigation feel instant anyway.
 	return (
-		<NavHrefLink href={href} prefetch={true} className={className}>
+		<NavHrefLink href={href} className={className}>
 			{children}
 		</NavHrefLink>
 	);

--- a/src/ui/sections/category-tile-grid/category-tile-grid.tsx
+++ b/src/ui/sections/category-tile-grid/category-tile-grid.tsx
@@ -1,8 +1,8 @@
 import { ArrowRight } from "lucide-react";
-import Image from "next/image";
-import { PLP_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { PLP_IMAGE_SIZES } from "@/lib/images";
 import { cn } from "@/lib/utils";
 import { NavHrefLink } from "@/ui/atoms/nav-href-link";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { Section, type SectionTone, type SectionWidth } from "@/ui/sections/section";
 import { SectionHeader, type SectionHeaderCta } from "@/ui/sections/section-header";
 
@@ -10,6 +10,8 @@ export interface CategoryTile {
 	title: string;
 	href: string;
 	image?: string | null;
+	/** Saleor rung set for `image`. Absent for sources with a single rung, which fall back to `next/image`. */
+	imageSrcSet?: string;
 	imageAlt?: string;
 	/** Small overline above the title (e.g. item count, category group). */
 	subtitle?: string;
@@ -112,12 +114,11 @@ export function CategoryTileGrid({
 									)}
 								>
 									{tile.image ? (
-										<Image
+										<SaleorImage
 											src={tile.image}
+											srcSet={tile.imageSrcSet}
 											alt={tile.imageAlt || tile.title}
-											fill
 											sizes={PLP_IMAGE_SIZES}
-											quality={PRODUCT_IMAGE_QUALITY}
 											className="object-contain p-8 transition-transform duration-slow ease-standard motion-reduce:transition-none md:group-hover:scale-105"
 										/>
 									) : null}
@@ -144,12 +145,11 @@ export function CategoryTileGrid({
 								)}
 							>
 								{tile.image ? (
-									<Image
+									<SaleorImage
 										src={tile.image}
+										srcSet={tile.imageSrcSet}
 										alt={tile.imageAlt || tile.title}
-										fill
 										sizes={PLP_IMAGE_SIZES}
-										quality={PRODUCT_IMAGE_QUALITY}
 										className="object-cover transition-transform duration-slow ease-standard motion-reduce:transition-none md:group-hover:scale-105"
 									/>
 								) : null}

--- a/src/ui/sections/editorial-hero/editorial-hero.tsx
+++ b/src/ui/sections/editorial-hero/editorial-hero.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from "react";
-import Image from "next/image";
+import { SPLIT_PANEL_IMAGE_SIZES } from "@/lib/images";
 import { cn } from "@/lib/utils";
 import { NavHrefLink } from "@/ui/atoms/nav-href-link";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { buttonClassName } from "@/ui/components/ui/button";
 
 export interface EditorialHeroCta {
@@ -19,6 +20,8 @@ export interface EditorialHeroProps {
 	secondaryCta?: EditorialHeroCta;
 	/** Large product/editorial image shown on the soft panel beside the copy. */
 	image?: string | null;
+	/** Saleor rung set for `image`. Absent for CMS uploads, which fall back to `next/image`. */
+	imageSrcSet?: string;
 	imageAlt?: string;
 	/** Rendered on the image panel when no image is provided. */
 	placeholder?: ReactNode;
@@ -55,6 +58,7 @@ export function EditorialHero({
 	primaryCta,
 	secondaryCta,
 	image,
+	imageSrcSet,
 	imageAlt = "",
 	placeholder,
 	id = "homepage-hero-heading",
@@ -102,12 +106,12 @@ export function EditorialHero({
 
 				<div className="relative order-1 min-h-[52vh] overflow-hidden bg-secondary lg:order-2 lg:min-h-[80vh]">
 					{image ? (
-						<Image
+						<SaleorImage
 							src={image}
+							srcSet={imageSrcSet}
 							alt={imageAlt}
-							fill
 							priority
-							sizes="(max-width: 1024px) 100vw, 50vw"
+							sizes={SPLIT_PANEL_IMAGE_SIZES}
 							className="object-contain p-10 sm:p-16 lg:p-20"
 						/>
 					) : (

--- a/src/ui/sections/image-with-text/image-with-text.tsx
+++ b/src/ui/sections/image-with-text/image-with-text.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import Image from "next/image";
-import { PLP_HERO_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { SPLIT_PANEL_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
 import { cn } from "@/lib/utils";
 import { NavHrefLink } from "@/ui/atoms/nav-href-link";
 import { WavePattern } from "@/ui/components/plp/wave-pattern";
@@ -83,7 +83,7 @@ export function ImageWithText({
 							alt={imageAlt}
 							fill
 							className={cn(isContain ? "object-contain p-10 sm:p-14 lg:p-16" : "object-cover")}
-							sizes={PLP_HERO_IMAGE_SIZES}
+							sizes={SPLIT_PANEL_IMAGE_SIZES}
 							quality={PRODUCT_IMAGE_QUALITY}
 						/>
 					) : (

--- a/src/ui/sections/image-with-text/image-with-text.tsx
+++ b/src/ui/sections/image-with-text/image-with-text.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from "react";
-import Image from "next/image";
-import { SPLIT_PANEL_IMAGE_SIZES, PRODUCT_IMAGE_QUALITY } from "@/lib/images";
+import { SPLIT_PANEL_IMAGE_SIZES } from "@/lib/images";
 import { cn } from "@/lib/utils";
 import { NavHrefLink } from "@/ui/atoms/nav-href-link";
+import { SaleorImage } from "@/ui/atoms/saleor-image";
 import { WavePattern } from "@/ui/components/plp/wave-pattern";
 import { buttonClassName } from "@/ui/components/ui/button";
 import type { SectionTone } from "@/ui/sections/section";
@@ -22,6 +22,8 @@ export interface ImageWithTextProps {
 	paragraphs: readonly string[];
 	eyebrow?: string;
 	image?: string | null;
+	/** Saleor rung set for `image`. Absent for CMS uploads, which fall back to `next/image`. */
+	imageSrcSet?: string;
 	imageAlt?: string;
 	imagePosition?: ImageWithTextPosition;
 	/** `contain` (on a soft panel) suits studio packshots; `cover` suits lifestyle photos. */
@@ -53,6 +55,7 @@ export function ImageWithText({
 	paragraphs,
 	eyebrow,
 	image,
+	imageSrcSet,
 	imageAlt = "",
 	imagePosition = "left",
 	imageFit = "cover",
@@ -78,13 +81,12 @@ export function ImageWithText({
 					)}
 				>
 					{hasImage && image ? (
-						<Image
+						<SaleorImage
 							src={image}
+							srcSet={imageSrcSet}
 							alt={imageAlt}
-							fill
 							className={cn(isContain ? "object-contain p-10 sm:p-14 lg:p-16" : "object-cover")}
 							sizes={SPLIT_PANEL_IMAGE_SIZES}
-							quality={PRODUCT_IMAGE_QUALITY}
 						/>
 					) : (
 						(placeholder ?? <WavePattern className="h-full w-full text-secondary" />)


### PR DESCRIPTION
Paper now spends Vercel budget on traffic and catalog change, not on re-deriving the same images and listings. Forks can port the same levers from [`docs/vercel-cost-optimization.md`](https://github.com/saleor/storefront/blob/feat/better-cost-control/docs/vercel-cost-optimization.md).

### Knobs, highest leverage first

1. **Catalog images leave `/_next/image`.** PLP cards, PDP gallery, and homepage Saleor images render a plain `<img srcset>` against Saleor's CDN ([`src/ui/atoms/saleor-image.tsx`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/ui/atoms/saleor-image.tsx)). Saleor already produced the WebP; we stop paying to transform it again. Escape hatch: `NEXT_PUBLIC_PAPER_IMAGE_PIPELINE=vercel` in [`.env.example`](https://github.com/saleor/storefront/blob/feat/better-cost-control/.env.example).

2. **`minimumCacheTTL` 4h → 31 days** in [`next.config.js`](https://github.com/saleor/storefront/blob/feat/better-cost-control/next.config.js). Thumbnail URLs are stable per (media id, size, format), so the cache lifetime now matches the content. Tunable via `NEXT_IMAGE_MIN_CACHE_TTL`.

3. **Webhook invalidation follows `saleor-event`** ([`src/lib/webhook-events.ts`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/lib/webhook-events.ts), [`src/app/api/revalidate/route.ts`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/app/api/revalidate/route.ts)). Unknown events are skipped. Stock and metadata updates bust the PDP only; listing tags move only when a card can change.

4. **Listing grids are cached; catalog backstop is 1h** ([`src/lib/catalog/get-product-listing.ts`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/lib/catalog/get-product-listing.ts), [`src/lib/cache-life-profiles.data.mjs`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/lib/cache-life-profiles.data.mjs)). Unfiltered / first-page / sort-only views no longer render on every request. Webhooks stay the freshness path.

5. **Every Saleor image selection carries `size` and `format: WEBP`** (e.g. [`src/graphql/ProductListItem.graphql`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/graphql/ProductListItem.graphql)). Bare `thumbnail { url }` was the original upload. Category / collection heroes are sized too.

6. **`remotePatterns` is an allowlist** in [`next.config.js`](https://github.com/saleor/storefront/blob/feat/better-cost-control/next.config.js). Production builds from Saleor Cloud hosts, the API host, and `IMAGE_ALLOWED_HOSTS`. The wildcard stays development-only.

7. **Width ladders match what we render** in [`next.config.js`](https://github.com/saleor/storefront/blob/feat/better-cost-control/next.config.js) and [`src/lib/images.ts`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/lib/images.ts). `deviceSizes` / `imageSizes` drop 2048/3840 and the unused small steps. The cart drawer declares `sizes` for its 80px slot ([`src/ui/components/cart/cart-drawer.tsx`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/ui/components/cart/cart-drawer.tsx)).

8. **GraphQL inter-request sleep is build-only** in [`src/lib/graphql.ts`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/lib/graphql.ts). Runtime already has a concurrency cap; the delay was billed wait. Override with `SALEOR_MIN_REQUEST_DELAY_MS`.

9. **Middleware matcher skips API, checkout, `_next`, and file extensions** ([`src/middleware.ts`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/middleware.ts)). Those paths already returned early; Vercel bills the invocation first.

10. **Category tiles use default prefetch** ([`src/ui/sections/category-tile-grid/category-tile-grid.tsx`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/ui/sections/category-tile-grid/category-tile-grid.tsx)). `prefetch={true}` under `partialPrefetching` is one RSC payload per tile on viewport entry.

11. **`/api/og` caps query length and caches harder** ([`src/app/api/og/route.tsx`](https://github.com/saleor/storefront/blob/feat/better-cost-control/src/app/api/og/route.tsx)). Nothing in the storefront generates these URLs today.

### Test plan

- [ ] Homepage, PLP, and PDP: catalog images load from Saleor (`srcset` on `<img>`), not `/_next/image`
- [ ] CMS / local assets still go through `next/image`
- [ ] `NEXT_PUBLIC_PAPER_IMAGE_PIPELINE=vercel` restores the optimizer path
- [ ] Stock webhook does not regenerate listing routes; `product_updated` does
- [ ] Unknown `saleor-event` is logged and skipped
- [ ] After `pnpm build`, the `data-nimg` audit lists only sources with no Saleor rung set