### PR TITLE
Fix cache public videos in the browser

### DIFF
--- a/docs/vercel-cost-optimization.md
+++ b/docs/vercel-cost-optimization.md
@@ -47,6 +47,7 @@ even once a window can be re-derived ~180 times a month.
 [ ] 11. Stop prefetching every link
 [ ] 12. Check for duplicate webhook subscriptions (Saleor app + direct)
 [ ] 13. Audit every remaining next/image call site for Saleor-backed sources
+[ ] 14. Public-asset Cache-Control must include video (and any other /public media)
 ```
 
 ---
@@ -294,6 +295,28 @@ createHash("sha1").update(rawBody).digest("hex").slice(0, 12);
 
 Do not use this to _drop_ deliveries — functions are multi-instance, so dedup here would be
 unreliable in exactly the way that silently loses invalidations.
+
+## 14. Cache `/public` media in the browser, including video
+
+Next.js defaults unmatched responses to `Cache-Control: public, max-age=0, must-revalidate`
+so HTML always revalidates. The `headers()` rule that overrides that for `/public` files is
+an extension allowlist. If `mp4` / `webm` / `mov` are missing, a hero loop inherits
+**document** caching: the browser re-requests it on every visit. Vercel Fast Data Transfer
+is bytes from the edge to the client, so a 33 MB file billed once per session dominates
+the meter even when the CDN already has a HIT.
+
+Paper's allowlist lives in `src/lib/public-asset-cache.data.mjs` (wired from `next.config.js`).
+Add the extension there — do not patch the regex inline. After deploy:
+
+```bash
+curl -sI https://<host>/videos/hero.mp4
+```
+
+You want `max-age=2592000` and `video/*`, not `text/html` + `max-age=0`.
+
+This is a guardrail for leftovers in `/public`. Catalog and CMS media should still be served
+from Saleor's CDN (item 5), not copied into the Next app. Browser cache only helps repeat
+visits; first-visit FDT is the file size.
 
 ---
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 import createNextIntlPlugin from "next-intl/plugin";
 import { paperCacheLifeProfiles } from "./src/lib/cache-life-profiles.data.mjs";
+import {
+	PUBLIC_ASSET_CACHE_CONTROL,
+	publicAssetCacheHeaderSource,
+} from "./src/lib/public-asset-cache.data.mjs";
 
 /** Hostnames for mobile/tunnel dev (ngrok, LAN). See ALLOWED_DEV_ORIGINS in .env.example */
 const allowedDevOrigins = process.env.ALLOWED_DEV_ORIGINS?.split(",")
@@ -134,14 +138,11 @@ const config = {
 					]
 				: []),
 			{
-				// Public folder assets - cache for 1 month (logos, favicons, etc.)
-				source: "/(.*)\\.(ico|png|jpg|jpeg|gif|svg|webp|woff|woff2|webmanifest)",
-				headers: [
-					{
-						key: "Cache-Control",
-						value: "public, max-age=2592000, stale-while-revalidate=31536000",
-					},
-				],
+				// /public leftovers (logos, fonts, same-origin video). Allowlist lives in
+				// public-asset-cache.data.mjs — a missed extension inherits document
+				// caching (max-age=0) and re-downloads on every visit (Fast Data Transfer).
+				source: publicAssetCacheHeaderSource(),
+				headers: [{ key: "Cache-Control", value: PUBLIC_ASSET_CACHE_CONTROL }],
 			},
 			{
 				// OG Image API — output is a pure function of the query string, and each render

--- a/src/lib/public-asset-cache.data.mjs
+++ b/src/lib/public-asset-cache.data.mjs
@@ -1,0 +1,55 @@
+/**
+ * Browser Cache-Control for same-origin files under `/public`.
+ *
+ * Next.js defaults unmatched responses to `public, max-age=0, must-revalidate`
+ * (document caching). A hero video that misses this list is re-downloaded on
+ * every visit and billed as Fast Data Transfer.
+ *
+ * Keep an allowlist — a catch-all `*.*` would also pin `/sitemap.xml` and
+ * `/robots.txt` for a month if those App Router routes are added later.
+ *
+ * Catalog and CMS media should not live in `/public`: serve them from Saleor's
+ * CDN (see the `ui-images` rule). This list is the guardrail for leftovers.
+ */
+
+export const PUBLIC_ASSET_FILE_EXTENSIONS = [
+	"ico",
+	"png",
+	"jpg",
+	"jpeg",
+	"gif",
+	"svg",
+	"webp",
+	"avif",
+	"woff",
+	"woff2",
+	"ttf",
+	"otf",
+	"eot",
+	"webmanifest",
+	"mp3",
+	"ogg",
+	"wav",
+	"mp4",
+	"webm",
+	"mov",
+	"m4v",
+];
+
+/** 30 days fresh, then stale-while-revalidate for a year. */
+export const PUBLIC_ASSET_CACHE_CONTROL = "public, max-age=2592000, stale-while-revalidate=31536000";
+
+/** `headers().source` for `next.config.js` — path-to-regexp, not a JS RegExp. */
+export function publicAssetCacheHeaderSource() {
+	return `/(.*)\\.(${PUBLIC_ASSET_FILE_EXTENSIONS.join("|")})`;
+}
+
+/** Same membership test as the header source: last path segment's extension. */
+export function isPublicAssetCachePath(pathname) {
+	const base = (pathname.split("?")[0] ?? "").toLowerCase();
+	const slash = base.lastIndexOf("/");
+	const filename = slash === -1 ? base : base.slice(slash + 1);
+	const dot = filename.lastIndexOf(".");
+	if (dot <= 0 || dot === filename.length - 1) return false;
+	return PUBLIC_ASSET_FILE_EXTENSIONS.includes(filename.slice(dot + 1));
+}

--- a/src/lib/public-asset-cache.test.ts
+++ b/src/lib/public-asset-cache.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+	PUBLIC_ASSET_CACHE_CONTROL,
+	PUBLIC_ASSET_FILE_EXTENSIONS,
+	isPublicAssetCachePath,
+	publicAssetCacheHeaderSource,
+} from "./public-asset-cache.data.mjs";
+
+describe("public asset browser cache", () => {
+	it("caches same-origin videos so a hero loop is not billed as FDT on every visit", () => {
+		for (const path of ["/videos/hero.mp4", "/hero.webm", "/promo.MOV", "/clip.m4v"]) {
+			expect(isPublicAssetCachePath(path), path).toBe(true);
+		}
+	});
+
+	it("caches the public-folder types Paper already ships", () => {
+		expect(isPublicAssetCachePath("/logo.svg")).toBe(true);
+		expect(isPublicAssetCachePath("/site.webmanifest")).toBe(true);
+		expect(isPublicAssetCachePath("/android-chrome-192x192.png")).toBe(true);
+	});
+
+	it("does not treat documents or app routes as public assets", () => {
+		for (const path of ["/en/us", "/api/og", "/sitemap.xml", "/robots.txt", "/favicon", "/"]) {
+			expect(isPublicAssetCachePath(path), path).toBe(false);
+		}
+	});
+
+	it("header source enumerates every allowlisted extension", () => {
+		const source = publicAssetCacheHeaderSource();
+		expect(source.startsWith("/(.*)\\.(")).toBe(true);
+		for (const ext of PUBLIC_ASSET_FILE_EXTENSIONS) {
+			expect(source).toContain(ext);
+		}
+	});
+
+	it("uses a month-long browser TTL, not document caching", () => {
+		expect(PUBLIC_ASSET_CACHE_CONTROL).toContain("max-age=2592000");
+		expect(PUBLIC_ASSET_CACHE_CONTROL).not.toContain("max-age=0");
+	});
+});


### PR DESCRIPTION
Same-origin mp4/webm/mov inherited document Cache-Control (max-age=0), so a hero loop was re-downloaded every visit and billed as Fast Data Transfer.