### PR TITLE
Fix signup Instant Navigations block and gate auth forms by session

### DIFF
--- a/src/app/(storefront)/[locale]/[channel]/(main)/login/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/login/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
 import { AuthFormSection } from "@/ui/components/auth/auth-form-section";
+import { AccountUnavailable } from "@/ui/components/account/account-unavailable";
 import { ConfirmAccountMode } from "@/ui/components/auth/confirm-account-mode";
 import { LoginForm } from "@/ui/components/login-form";
 import {
@@ -12,6 +13,7 @@ import {
 import { searchParamsRecordToGetter } from "@/lib/auth/search-params-record";
 import { CurrentUserDocument } from "@/gql/graphql";
 import { fetchAuthenticatedUserIfSession } from "@/lib/auth/fetch-authenticated-user";
+import { resolveSessionUser } from "@/lib/auth/resolve-session-user";
 import { buildStorefrontPath } from "@/lib/storefront-path";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
@@ -91,15 +93,19 @@ function LoginSkeleton() {
 }
 
 async function LoginContent({ locale, channel }: { locale: string; channel: string }) {
-	// Request-dynamic — never serve a cached login redirect from a prior authenticated session.
+	// Uncaught — `hasAuthSession` swallows `cookies()` throws and can hide this hole.
 	await cookies();
 
-	const result = await fetchAuthenticatedUserIfSession(CurrentUserDocument, {
-		cache: "no-cache",
-	});
+	const auth = await resolveSessionUser(() =>
+		fetchAuthenticatedUserIfSession(CurrentUserDocument, { cache: "no-cache" }),
+	);
 
-	if (result?.ok && result.data.me) {
+	if (auth.status === "authenticated") {
 		redirect(buildStorefrontPath(locale, channel));
+	}
+
+	if (auth.status === "unavailable") {
+		return <AccountUnavailable locale={locale} />;
 	}
 
 	return (

--- a/src/app/(storefront)/[locale]/[channel]/(main)/signup/page.tsx
+++ b/src/app/(storefront)/[locale]/[channel]/(main)/signup/page.tsx
@@ -1,7 +1,14 @@
 import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
 import { AuthFormSection } from "@/ui/components/auth/auth-form-section";
+import { AccountUnavailable } from "@/ui/components/account/account-unavailable";
 import { SignUpForm } from "@/ui/components/sign-up-form";
+import { CurrentUserDocument } from "@/gql/graphql";
+import { fetchAuthenticatedUserIfSession } from "@/lib/auth/fetch-authenticated-user";
+import { resolveSessionUser } from "@/lib/auth/resolve-session-user";
+import { buildStorefrontPath } from "@/lib/storefront-path";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
 	const { locale } = await params;
@@ -12,13 +19,39 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 	};
 }
 
-export default function SignUpPage() {
+type SignUpPageProps = {
+	params: Promise<{ locale: string; channel: string }>;
+};
+
+export default function SignUpPage(props: SignUpPageProps) {
 	return (
 		<Suspense fallback={<SignUpSkeleton />}>
-			<AuthFormSection>
-				<SignUpForm />
-			</AuthFormSection>
+			<SignUpContent params={props.params} />
 		</Suspense>
+	);
+}
+
+async function SignUpContent({ params }: { params: Promise<{ locale: string; channel: string }> }) {
+	// Uncaught — `hasAuthSession` swallows `cookies()` throws and can hide this hole.
+	await cookies();
+
+	const { locale, channel } = await params;
+	const auth = await resolveSessionUser(() =>
+		fetchAuthenticatedUserIfSession(CurrentUserDocument, { cache: "no-cache" }),
+	);
+
+	if (auth.status === "authenticated") {
+		redirect(buildStorefrontPath(locale, channel, "/account"));
+	}
+
+	if (auth.status === "unavailable") {
+		return <AccountUnavailable locale={locale} />;
+	}
+
+	return (
+		<AuthFormSection>
+			<SignUpForm />
+		</AuthFormSection>
 	);
 }
 
@@ -54,7 +87,7 @@ function SignUpSkeleton() {
 							<div className="h-4 w-32 animate-pulse rounded bg-secondary" />
 							<div className="h-12 w-full animate-pulse rounded-md bg-secondary" />
 						</div>
-						<div className="bg-foreground/10 h-12 w-full animate-pulse rounded-md" />
+						<div className="h-12 w-full animate-pulse rounded-md bg-foreground/10" />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
generateMetadata on /signup reads locale params while the page body was static, so Next 16.3 blocked prefetch. Signup (and login) now read cookies inside <Suspense>, redirect when already signed in, and show the existing unavailable state if Saleor does not answer - not another sign-up form.